### PR TITLE
importlib-metadata version upgraded

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ install_requires =
     docstring-parser==0.13
     gdown==4.2.0
     googledrivedownloader==0.4
-    importlib-metadata==4.8.1
+    importlib-metadata==4.10.0
     jsonpickle==1.3.0
     lightgbm==3.3.1
     napari==0.4.12


### PR DESCRIPTION
This PR upgrades the required importlib-metadata version to 4.10.0