### PR TITLE
Refactor: bringing back ArrayLike type annotations to it.transforms

### DIFF
--- a/aydin/it/transforms/attenuation.py
+++ b/aydin/it/transforms/attenuation.py
@@ -3,7 +3,7 @@ from typing import Union, Sequence
 import numpy
 from numba import jit
 
-# from numpy.typing import ArrayLike
+from numpy.typing import ArrayLike
 
 from aydin.it.transforms.base import ImageTransformBase
 from aydin.util.log.log import lsection, lprint
@@ -80,7 +80,7 @@ class AttenuationTransform(ImageTransformBase):
     def __repr__(self):
         return self.__str__()
 
-    def preprocess(self, array):
+    def preprocess(self, array: ArrayLike):
 
         with lsection(
             f"Correcting attenuation for array of shape: {array.shape} and dtype: {array.dtype}:"
@@ -152,7 +152,7 @@ class AttenuationTransform(ImageTransformBase):
         else:
             raise ValueError(f"Mode '{self.mode}' for attenuation correction unknown!")
 
-    def postprocess(self, array):
+    def postprocess(self, array: ArrayLike):
 
         if not self.do_postprocess:
             return array

--- a/aydin/it/transforms/base.py
+++ b/aydin/it/transforms/base.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 
-# from numpy.typing import ArrayLike
+from numpy.typing import ArrayLike
 
 
 class ImageTransformBase(ABC):
@@ -38,11 +38,11 @@ class ImageTransformBase(ABC):
         self.do_postprocess = do_postprocess
 
     @abstractmethod
-    def preprocess(self, array):
+    def preprocess(self, array: ArrayLike):
         """ """
         raise NotImplementedError()
 
     @abstractmethod
-    def postprocess(self, array):
+    def postprocess(self, array: ArrayLike):
         """ """
         raise NotImplementedError()

--- a/aydin/it/transforms/deskew.py
+++ b/aydin/it/transforms/deskew.py
@@ -1,6 +1,6 @@
 import numpy
 
-# from numpy.typing import ArrayLike
+from numpy.typing import ArrayLike
 
 from aydin.it.transforms.base import ImageTransformBase
 from aydin.util.log.log import lsection, lprint
@@ -82,7 +82,7 @@ class DeskewTransform(ImageTransformBase):
     def __repr__(self):
         return self.__str__()
 
-    def preprocess(self, array):
+    def preprocess(self, array: ArrayLike):
         with lsection(
             f"Deskewing (delta={self.delta}, z_axis={self.z_axis}, skew_axis={self.skew_axis}, pad={self.pad}) array of shape: {array.shape} and dtype: {array.dtype}:"
         ):
@@ -91,7 +91,7 @@ class DeskewTransform(ImageTransformBase):
             else:
                 return array
 
-    def postprocess(self, array):
+    def postprocess(self, array: ArrayLike):
         if not self.do_postprocess:
             return array
         with lsection(
@@ -102,7 +102,7 @@ class DeskewTransform(ImageTransformBase):
             else:
                 return array
 
-    def deskew(self, array, pad_mode='wrap'):
+    def deskew(self, array: ArrayLike, pad_mode='wrap'):
         array = self._permutate(array)
         array = self._skew_transform(
             array, self.delta, pad=True, crop=False, pad_mode=pad_mode
@@ -110,7 +110,7 @@ class DeskewTransform(ImageTransformBase):
         array = self._depermutate(array)
         return array
 
-    def reskew(self, array):
+    def reskew(self, array: ArrayLike):
         array = self._permutate(array)
         array = self._skew_transform(
             array, -self.delta, pad=False, crop=True, pad_mode=''
@@ -118,17 +118,17 @@ class DeskewTransform(ImageTransformBase):
         array = self._depermutate(array)
         return array
 
-    def _permutate(self, array):
+    def _permutate(self, array: ArrayLike):
         permutation = self._get_permutation(array)
         array = numpy.transpose(array, axes=permutation)
         return array
 
-    def _depermutate(self, array):
+    def _depermutate(self, array: ArrayLike):
         permutation = self._get_permutation(array, inverse=True)
         array = numpy.transpose(array, axes=permutation)
         return array
 
-    def _get_permutation(self, array, inverse=False):
+    def _get_permutation(self, array: ArrayLike, inverse=False):
         permutation = (self.z_axis, self.skew_axis) + tuple(
             axis
             for axis in range(array.ndim)
@@ -139,7 +139,7 @@ class DeskewTransform(ImageTransformBase):
         return permutation
 
     @staticmethod
-    def _skew_transform(array, delta, pad, crop, pad_mode='wrap'):
+    def _skew_transform(array: ArrayLike, delta, pad, crop, pad_mode='wrap'):
         """
         This method assumes that the first dimension (index=0) is the z dimension,
         and the second dimension (index=1) is the 'skewed' dimension.

--- a/aydin/it/transforms/fixedpattern.py
+++ b/aydin/it/transforms/fixedpattern.py
@@ -2,7 +2,7 @@ import itertools
 from typing import List, Tuple, Any, Sequence, Union
 import numpy
 
-# from numpy.typing import ArrayLike
+from numpy.typing import ArrayLike
 from scipy.ndimage import gaussian_filter
 
 from aydin.it.transforms.base import ImageTransformBase
@@ -107,7 +107,7 @@ class FixedPatternTransform(ImageTransformBase):
     def __repr__(self):
         return self.__str__()
 
-    def preprocess(self, array):
+    def preprocess(self, array: ArrayLike):
 
         with lsection(
             f"Removing axis-aligned fixed patterns for array of shape: {array.shape} and dtype: {array.dtype}:"
@@ -148,7 +148,7 @@ class FixedPatternTransform(ImageTransformBase):
 
             return new_array
 
-    def postprocess(self, array):
+    def postprocess(self, array: ArrayLike):
 
         if not self.do_postprocess:
             return array

--- a/aydin/it/transforms/highpass.py
+++ b/aydin/it/transforms/highpass.py
@@ -1,8 +1,6 @@
 import numbers
-
 import numpy
-
-# from numpy.typing import ArrayLike
+from numpy.typing import ArrayLike
 from scipy.ndimage import median_filter, gaussian_filter
 
 from aydin.it.transforms.base import ImageTransformBase
@@ -85,7 +83,7 @@ class HighpassTransform(ImageTransformBase):
     def __repr__(self):
         return self.__str__()
 
-    def preprocess(self, array):
+    def preprocess(self, array: ArrayLike):
 
         with lsection(
             f"Applies high-pass filter of sigma {self.sigma} {'and median filtering' if self.median_filtering else ''} to array of shape: {array.shape} and dtype: {array.dtype}"
@@ -108,7 +106,7 @@ class HighpassTransform(ImageTransformBase):
 
             return new_array
 
-    def postprocess(self, array):
+    def postprocess(self, array: ArrayLike):
 
         if not self.do_postprocess:
             return array
@@ -133,7 +131,7 @@ class HighpassTransform(ImageTransformBase):
 
             return new_array
 
-    def _low_pass_filtering(self, array):
+    def _low_pass_filtering(self, array: ArrayLike):
 
         lprint(f"Sigma for high-pass filter is: {self.sigma}")
 

--- a/aydin/it/transforms/histogram.py
+++ b/aydin/it/transforms/histogram.py
@@ -1,6 +1,6 @@
 import numpy
 
-# from numpy.typing import ArrayLike
+from numpy.typing import ArrayLike
 from skimage.exposure import equalize_adapthist, cumulative_distribution
 
 from aydin.it.transforms.base import ImageTransformBase
@@ -71,7 +71,7 @@ class HistogramEqualisationTransform(ImageTransformBase):
     def __repr__(self):
         return self.__str__()
 
-    def preprocess(self, array):
+    def preprocess(self, array: ArrayLike):
 
         with lsection(
             f"Equalises histogram for array of shape: {array.shape} and dtype: {array.dtype}"
@@ -93,7 +93,7 @@ class HistogramEqualisationTransform(ImageTransformBase):
 
             return new_array
 
-    def postprocess(self, array):
+    def postprocess(self, array: ArrayLike):
 
         if not self.do_postprocess:
             return array

--- a/aydin/it/transforms/motion.py
+++ b/aydin/it/transforms/motion.py
@@ -4,7 +4,7 @@ from typing import Union, Optional, Sequence
 import numpy
 import scipy
 
-# from numpy.typing import ArrayLike
+from numpy.typing import ArrayLike
 from scipy.ndimage import gaussian_filter
 from scipy.optimize import curve_fit
 
@@ -124,7 +124,7 @@ class MotionStabilisationTransform(ImageTransformBase):
     def __repr__(self):
         return self.__str__()
 
-    def preprocess(self, array):
+    def preprocess(self, array: ArrayLike):
         with lsection(f"Motion-correcting array of shape: {array.shape}:"):
 
             self._original_dtype = array.dtype
@@ -154,7 +154,7 @@ class MotionStabilisationTransform(ImageTransformBase):
                 array = self._depermutate(array, axis=axis)
             return array
 
-    def postprocess(self, array):
+    def postprocess(self, array: ArrayLike):
 
         if not self.do_postprocess:
             return array
@@ -180,24 +180,24 @@ class MotionStabilisationTransform(ImageTransformBase):
 
             return array
 
-    def _permutate(self, array, axis: int):
+    def _permutate(self, array: ArrayLike, axis: int):
         permutation = self._get_permutation(array, axis=axis)
         array = numpy.transpose(array, axes=permutation)
         return array
 
-    def _depermutate(self, array, axis: int):
+    def _depermutate(self, array: ArrayLike, axis: int):
         permutation = self._get_permutation(array, axis=axis, inverse=True)
         array = numpy.transpose(array, axes=permutation)
         return array
 
-    def _get_permutation(self, array, axis: int, inverse=False):
+    def _get_permutation(self, array: ArrayLike, axis: int, inverse=False):
         permutation = (axis,) + tuple(a for a in range(array.ndim) if a != axis)
         if inverse:
             permutation = numpy.argsort(permutation)
         return permutation
 
 
-def _shift_transform(array, shifts, pad, crop, pad_mode='wrap'):
+def _shift_transform(array: ArrayLike, shifts, pad, crop, pad_mode='wrap'):
     """ """
 
     min_shift = abs(numpy.min(shifts, axis=0))
@@ -234,7 +234,7 @@ def _shift_transform(array, shifts, pad, crop, pad_mode='wrap'):
 
 
 def _measure_shifts(
-    array,
+    array: ArrayLike,
     reference_index: Optional[int] = None,
     center: bool = False,
     max_pixel_shift: Optional[int] = None,
@@ -396,7 +396,7 @@ def _find_shift(a, b, max_pixel_shift: int = 64, mode: str = 'com', sigma: float
     return shift, correlation
 
 
-def _fast_denoise(array, sigma):
+def _fast_denoise(array: ArrayLike, sigma):
     denoised = gaussian_filter(array, sigma=sigma, mode='wrap')
     return denoised
 

--- a/aydin/it/transforms/padding.py
+++ b/aydin/it/transforms/padding.py
@@ -1,6 +1,6 @@
 import numpy
 
-# from numpy.typing import ArrayLike
+from numpy.typing import ArrayLike
 
 from aydin.it.transforms.base import ImageTransformBase
 from aydin.util.log.log import lsection, lprint
@@ -82,7 +82,7 @@ class PaddingTransform(ImageTransformBase):
     def __repr__(self):
         return self.__str__()
 
-    def preprocess(self, array):
+    def preprocess(self, array: ArrayLike):
         with lsection(
             f"Padding array of shape: {array.shape} with {self.pad_width} voxels and mode: {self.mode}:"
         ):
@@ -91,7 +91,7 @@ class PaddingTransform(ImageTransformBase):
             )
             return padded_array
 
-    def postprocess(self, array):
+    def postprocess(self, array: ArrayLike):
         if not self.do_postprocess:
             return array
 
@@ -102,7 +102,7 @@ class PaddingTransform(ImageTransformBase):
             return new_array
 
 
-def _pad(array, mode: str, pad_width: int, min_length_to_pad: int):
+def _pad(array: ArrayLike, mode: str, pad_width: int, min_length_to_pad: int):
 
     # Compute pad width:
     if isinstance(pad_width, int):
@@ -122,7 +122,7 @@ def _pad(array, mode: str, pad_width: int, min_length_to_pad: int):
     return padded_array, pad_width
 
 
-def _unpad(array, pad_width):
+def _unpad(array: ArrayLike, pad_width):
 
     # Compute slice:
     slices = []

--- a/aydin/it/transforms/periodic.py
+++ b/aydin/it/transforms/periodic.py
@@ -1,7 +1,7 @@
 import numpy
 import scipy
 
-# from numpy.typing import ArrayLike
+from numpy.typing import ArrayLike
 from scipy.ndimage import minimum_filter
 from skimage.feature import peak_local_max
 
@@ -88,7 +88,7 @@ class PeriodicNoiseSuppressionTransform(ImageTransformBase):
     def __repr__(self):
         return self.__str__()
 
-    def preprocess(self, array):
+    def preprocess(self, array: ArrayLike):
 
         with lsection(
             f"Applies periodic noise suppression to array of shape: {array.shape} and dtype: {array.dtype}"
@@ -96,7 +96,7 @@ class PeriodicNoiseSuppressionTransform(ImageTransformBase):
             new_array = self._suppress_periodic_patterns(array)
             return new_array
 
-    def postprocess(self, array):
+    def postprocess(self, array: ArrayLike):
 
         if not self.do_postprocess:
             return array
@@ -111,7 +111,7 @@ class PeriodicNoiseSuppressionTransform(ImageTransformBase):
                 new_array = self._suppress_periodic_patterns(array)
             return new_array
 
-    def _suppress_periodic_patterns(self, array):
+    def _suppress_periodic_patterns(self, array: ArrayLike):
         self._original_dtype = array.dtype
         array = array.astype(numpy.float32, copy=False)
 
@@ -186,7 +186,7 @@ class PeriodicNoiseSuppressionTransform(ImageTransformBase):
 
         return new_array
 
-    def _reapply_periodic_patterns(self, array):
+    def _reapply_periodic_patterns(self, array: ArrayLike):
         array = array.astype(numpy.float32, copy=False)
         ft = scipy.fft.fftn(array, workers=-1)
         ft = scipy.fft.fftshift(ft)

--- a/aydin/it/transforms/range.py
+++ b/aydin/it/transforms/range.py
@@ -1,8 +1,7 @@
 from typing import Optional
 
 import numpy
-
-# from numpy.typing import ArrayLike
+from numpy.typing import ArrayLike
 
 from aydin.it.normalisers.base import NormaliserBase
 from aydin.it.normalisers.minmax import MinMaxNormaliser
@@ -106,7 +105,7 @@ class RangeTransform(ImageTransformBase):
     def __repr__(self):
         return self.__str__()
 
-    def preprocess(self, array):
+    def preprocess(self, array: ArrayLike):
 
         with lsection(
             f"Normalizing value range ({self.mode}) for array of shape: {array.shape} and dtype: {array.dtype}"
@@ -127,7 +126,7 @@ class RangeTransform(ImageTransformBase):
             self._normaliser = normaliser
             return new_array
 
-    def postprocess(self, array):
+    def postprocess(self, array: ArrayLike):
 
         if not self.do_postprocess:
             return array

--- a/aydin/it/transforms/salt_pepper.py
+++ b/aydin/it/transforms/salt_pepper.py
@@ -1,6 +1,6 @@
 import numpy
 
-# from numpy.typing import ArrayLike
+from numpy.typing import ArrayLike
 from numpy import sort
 from scipy.ndimage import uniform_filter
 
@@ -114,7 +114,7 @@ class SaltPepperTransform(ImageTransformBase):
     def __repr__(self):
         return self.__str__()
 
-    def preprocess(self, array):
+    def preprocess(self, array: ArrayLike):
 
         with lsection(
             f"Broken Pixels Correction for array of shape: {array.shape} and dtype: {array.dtype}:"
@@ -136,12 +136,12 @@ class SaltPepperTransform(ImageTransformBase):
 
             return array
 
-    def postprocess(self, array):
+    def postprocess(self, array: ArrayLike):
         # undoing this transform is unpractical and unlikely to be usefull
         array = array.astype(self._original_dtype, copy=False)
         return array
 
-    def _repeated_value_method(self, array):
+    def _repeated_value_method(self, array: ArrayLike):
         with lsection(
             "Correcting for wrong pixels values using the 'repeated-value' approach:"
         ):
@@ -292,7 +292,7 @@ class SaltPepperTransform(ImageTransformBase):
         return median, error
 
 
-def _otsu_split(array):
+def _otsu_split(array: ArrayLike):
     # Flatten array:
     shape = array.shape
     array = array.reshape(-1)

--- a/aydin/it/transforms/variance_stabilisation.py
+++ b/aydin/it/transforms/variance_stabilisation.py
@@ -1,7 +1,7 @@
 import numpy
 from numba import jit
 
-# from numpy.typing import ArrayLike
+from numpy.typing import ArrayLike
 from sklearn.base import TransformerMixin
 from sklearn.preprocessing import PowerTransformer, QuantileTransformer
 
@@ -94,7 +94,7 @@ class VarianceStabilisationTransform(ImageTransformBase):
     def __repr__(self):
         return self.__str__()
 
-    def preprocess(self, array):
+    def preprocess(self, array: ArrayLike):
 
         with lsection(
             f"Stabilising variance ({self.mode}) for array of shape: {array.shape} and dtype: {array.dtype}"
@@ -185,7 +185,7 @@ class VarianceStabilisationTransform(ImageTransformBase):
 
             return new_array
 
-    def postprocess(self, array):
+    def postprocess(self, array: ArrayLike):
 
         if not self.do_postprocess:
             return array


### PR DESCRIPTION
This PR brings back the `numpy.typing.ArrayLike` type annotations to `aydin.it.transforms.*` as right now we can depend on a more recent version of numpy.