### PR TITLE
GUI: Hiding advanced processing tabs when basic mode is active

### DIFF
--- a/aydin/gui/_qt/transforms_tab_widget.py
+++ b/aydin/gui/_qt/transforms_tab_widget.py
@@ -53,6 +53,6 @@ class TransformsTabWidget(QTabWidget):
     def set_advanced_enabled(self, enable: bool = False):
         for index, item_widget in enumerate(self.list_of_item_widgets):
             if "(advanced)" in item_widget.transform_class.__doc__:
-                self.setTabEnabled(index, enable)
+                self.setTabVisible(index, enable)
 
             item_widget.constructor_arguments_widget.set_advanced_enabled(enable=enable)


### PR DESCRIPTION
This PR basically hides the advanced processing tabs instead of just disabling them(current behavior). That's it.