### PR TITLE
GUI: Saving processing related details

### DIFF
--- a/aydin/cli/cli.py
+++ b/aydin/cli/cli.py
@@ -104,14 +104,15 @@ def denoise(files, **kwargs):
         noisy2train = apply_slicing(noisy, kwargs['training_slicing'])
         noisy2infer = apply_slicing(noisy, kwargs['inference_slicing'])
 
-        if len(filenames) == 1:
-            if kwargs["batch_axes"]:
-                noisy_metadata.batch_axes = ast.literal_eval(kwargs["batch_axes"])
-                kwargs.pop("batch_axes")
+        if kwargs["batch_axes"] is not None and len(filenames) == 1:
+            noisy_metadata.batch_axes = ast.literal_eval(kwargs["batch_axes"])
 
-            if kwargs["channel_axes"]:
-                noisy_metadata.channel_axes = ast.literal_eval(kwargs["channel_axes"])
-                kwargs.pop("channel_axes")
+        kwargs.pop("batch_axes")
+
+        if kwargs["channel_axes"] is not None and len(filenames) == 1:
+            noisy_metadata.channel_axes = ast.literal_eval(kwargs["channel_axes"])
+
+        kwargs.pop("channel_axes")
 
         if kwargs['use_model']:
             shutil.unpack_archive(

--- a/aydin/gui/main_page.py
+++ b/aydin/gui/main_page.py
@@ -305,6 +305,7 @@ class MainPage(QWidget):
 
     def save_options_json(self, path=None):
         args_dict = self.tabs["Denoise"].lower_level_args
+        args_dict["processing"] = self.tabs["Pre/Post-Processing"].transforms
 
         if path is None:
             image_paths = [

--- a/aydin/restoration/denoise/noise2selfcnn.py
+++ b/aydin/restoration/denoise/noise2selfcnn.py
@@ -41,7 +41,9 @@ class Noise2SelfCNN(DenoiseRestorationBase):
         """
         super().__init__()
         self.lower_level_args = lower_level_args
-        self.backend_it, self.backend_or_model = ("cnn", "jinet") if variant is None else variant.split("-")
+        self.backend_it, self.backend_or_model = (
+            ("cnn", "jinet") if variant is None else variant.split("-")
+        )
 
         self.input_model_path = input_model_path
         self.use_model_flag = use_model

--- a/aydin/restoration/denoise/util/denoise_utils.py
+++ b/aydin/restoration/denoise/util/denoise_utils.py
@@ -32,6 +32,13 @@ def get_denoiser_class_instance(variant, lower_level_args=None, it_transforms=No
 
     denoiser_class = response.__getattribute__(elem)
 
+    if (
+        it_transforms is None
+        and lower_level_args is not None
+        and lower_level_args["processing"]
+    ):
+        it_transforms = lower_level_args["processing"]
+
     return denoiser_class(
         lower_level_args=lower_level_args, it_transforms=it_transforms
     )


### PR DESCRIPTION
This PR introduces changes to include processing tab related details in saved .zip file. As users might prefer different settings of pre/post-processing, this will be helpful for reproducibility of Aydin results.