### PR TITLE
BUG: Aydin CLI was not saving model

### DIFF
--- a/aydin/cli/cli.py
+++ b/aydin/cli/cli.py
@@ -11,7 +11,7 @@ from aydin.gui.gui import run
 from aydin.it.base import ImageTranslatorBase
 from aydin.restoration.deconvolve.lr import LucyRichardson
 from aydin.io.io import imwrite, imread
-from aydin.io.utils import get_output_image_path
+from aydin.io.utils import get_output_image_path, get_save_model_path
 from aydin.restoration.denoise.util.denoise_utils import get_denoiser_class_instance
 from aydin.util.misc.json import load_any_json
 from aydin.util.log.log import lprint, Log
@@ -114,6 +114,8 @@ def denoise(files, **kwargs):
 
         kwargs.pop("channel_axes")
 
+        output_path, index_counter = get_output_image_path(path)
+
         if kwargs['use_model']:
             shutil.unpack_archive(
                 input_model_path, os.path.dirname(input_model_path), "zip"
@@ -131,11 +133,11 @@ def denoise(files, **kwargs):
             denoised = response.astype(noisy2infer.dtype, copy=False)
             shutil.rmtree(input_model_path[:-4])
         else:
-            n2s = get_denoiser_class_instance(
+            denoiser = get_denoiser_class_instance(
                 lower_level_args=lower_level_args, variant=backend
             )
 
-            n2s.train(
+            denoiser.train(
                 noisy2train,
                 batch_axes=noisy_metadata.batch_axes
                 if noisy_metadata is not None
@@ -147,7 +149,7 @@ def denoise(files, **kwargs):
                 **kwargs,
             )
 
-            denoised = n2s.denoise(
+            denoised = denoiser.denoise(
                 noisy2infer,
                 batch_axes=noisy_metadata.batch_axes
                 if noisy_metadata is not None
@@ -157,8 +159,10 @@ def denoise(files, **kwargs):
                 else None,
             )
 
-        path, index_counter = get_output_image_path(path)
-        imwrite(denoised, path)
+            model_path = get_save_model_path(path, passed_counter=index_counter)
+            denoiser.save_model(model_path)
+
+        imwrite(denoised, output_path)
         lprint("DONE")
 
 

--- a/aydin/restoration/denoise/base.py
+++ b/aydin/restoration/denoise/base.py
@@ -144,13 +144,15 @@ class DenoiseRestorationBase(ABC):
         format = "zip"
         archive_from = os.path.dirname(source)
         archive_to = os.path.basename(source.strip(os.sep))
-        shutil.make_archive(name, format, archive_from, archive_to)
+
         if os.path.exists(os.path.join(destination, f"{name}.{format}")):
             lprint(
                 "Previously existing model will be deleted before saving the new model"
             )
             os.remove(os.path.join(destination, f"{name}.{format}"))
-        shutil.move(f"{name}.{format}", destination)
+
+        shutil.make_archive(name, format, archive_from, archive_to)
+        # shutil.move(f"{name}.{format}", destination)
 
     def save_model(self, model_path):
         """Saves the latest trained model next to the input image file.


### PR DESCRIPTION
This PR fixes the problem with Aydin CLI and makes it saves model by default  when use-model flag is not in use.