### PR TITLE
GUI: editable output paths

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Thank you for taking the time to contribute!
 
 We can't think of everything. If you've got a good idea for a feature, then please let us know!
 
-Feature suggestions are embraced, but will often be filed for a rainy day. If you require a feature urgently it's best to write it yourself. Don't forget to share ;)
+Feature suggestions are embraced, but will often be filed for a rainy day. If you require a feature urgently it's best to write it yourself. Don't forget to share :)
 
 When suggesting a feature, make sure to:
 
@@ -51,6 +51,7 @@ Once you're ready to share your contribution with us you should submit it as a P
 
 #### Do
 
+* Do use our own internal logging [API](https://github.com/royerlab/aydin/blob/master/aydin/util/log/log.py)
 * Do use pep8 style guidelines + our preferences with `black` formatter
 * Use NumPy style docstrings
 * Do comment your code where necessary
@@ -60,7 +61,7 @@ Once you're ready to share your contribution with us you should submit it as a P
 
 #### Don't
 
-* Don't include any license information in your examples- our repositories are GPLv3 licensed
+* Don't include any license information in your examples- our repositories are BSD-3-Clause License d
 * Don't try to do too much at once- submit one or two examples at a time, and be receptive to feedback
 * Don't submit multiple variations of the same example, demonstrate one thing concisely
 

--- a/aydin/gui/_qt/job_runners/denoise_job_runner.py
+++ b/aydin/gui/_qt/job_runners/denoise_job_runner.py
@@ -42,8 +42,11 @@ class DenoiseJobRunner(QWidget):
 
         results = []
 
-        for training_image, inference_image, image_path in zip(
-            self.training_images, self.inference_images, self.image_paths
+        for training_image, inference_image, image_path, output_folder in zip(
+            self.training_images,
+            self.inference_images,
+            self.image_paths,
+            self.output_folders,
         ):
             self.denoiser.train(
                 training_image, batch_axes=self.batch_axes, chan_axes=self.channel_axes
@@ -57,19 +60,25 @@ class DenoiseJobRunner(QWidget):
                 )
                 results.append(denoised)
 
-                output_path, file_counter = get_output_image_path(image_path)
+                output_path, file_counter = get_output_image_path(
+                    image_path, output_folder=output_folder
+                )
 
                 imwrite(denoised, output_path)
                 if self.save_options_json:
                     json_path = get_options_json_path(
-                        image_path, passed_counter=file_counter
+                        image_path,
+                        passed_counter=file_counter,
+                        output_folder=output_folder,
                     )
                     self.parent.save_options_json(json_path)
                     lprint(f"DONE, options json written in {json_path}")
 
                 if self.save_model:
                     model_path = get_save_model_path(
-                        image_path, passed_counter=file_counter
+                        image_path,
+                        passed_counter=file_counter,
+                        output_folder=output_folder,
                     )
                     self.denoiser.save_model(model_path)
                     lprint(f"DONE, trained model written in {model_path}")
@@ -101,6 +110,7 @@ class DenoiseJobRunner(QWidget):
     def prep_and_run(self):
         # Get images and their related data
         self.image_paths = [i[5] for i in self.parent.data_model.images_to_denoise]
+        self.output_folders = [i[6] for i in self.parent.data_model.images_to_denoise]
         if len(self.image_paths) == 0:
             lprint("Aydin cannot be started with no image")
             return

--- a/aydin/gui/tabs/data_model.py
+++ b/aydin/gui/tabs/data_model.py
@@ -191,6 +191,12 @@ class DataModel:
                 self.update_dimensions_tabview()
                 self.update_cropping_tabview()
 
+    def update_image_output_folder(self, filename, new_value):
+        #  TODO: write proper docstrings here
+        for imagelist_item in self._images:
+            if imagelist_item[0] == filename:
+                imagelist_item[6] = new_value
+
     def set_split_channels(self, filename, filepath, new_value: bool):
         """Method to split/de-split channels of an image with
         corresponding filename.

--- a/aydin/gui/tabs/data_model.py
+++ b/aydin/gui/tabs/data_model.py
@@ -1,3 +1,4 @@
+import pathlib
 from copy import deepcopy
 from os import listdir
 from os.path import join, isfile, isdir
@@ -127,7 +128,15 @@ class DataModel:
         """
         for path, (array, metadata) in new_images.items():
             self._images.append(
-                [Path(path).name, array, metadata, train_on, denoise, path]
+                [
+                    Path(path).name,
+                    array,
+                    metadata,
+                    train_on,
+                    denoise,
+                    path,
+                    str(pathlib.Path(path).resolve().parent),
+                ]
             )
 
         self.update_images_tabview()

--- a/aydin/gui/tabs/qt/images.py
+++ b/aydin/gui/tabs/qt/images.py
@@ -50,7 +50,7 @@ class ImagesTab(QWidget):
 
         self.image_list_tree_widget.setEditTriggers(QAbstractItemView.NoEditTriggers)
 
-        self.image_list_tree_widget.itemDoubleClicked.connect(self.onDoubleClick)
+        self.image_list_tree_widget.itemDoubleClicked.connect(self.onItemDoubleClick)
 
         self.image_list_tree_widget.header().sectionClicked.connect(
             self.onSectionClicked
@@ -81,22 +81,30 @@ class ImagesTab(QWidget):
     def onSectionClicked(self, column):
         if column == 0:
             return
-        for idx, item in enumerate(
-            iter_tree_widget(self.image_list_tree_widget.invisibleRootItem())
-        ):
-            if idx == 0:
-                continue
-            elif idx == 1:
-                state_to_be_set = (
-                    Qt.Unchecked
-                    if item.checkState(column) == Qt.Checked
-                    else Qt.Checked
-                )
+        elif column == 1:
+            for idx, item in enumerate(
+                iter_tree_widget(self.image_list_tree_widget.invisibleRootItem())
+            ):
+                if idx == 0:
+                    continue
+                elif idx == 1:
+                    state_to_be_set = (
+                        Qt.Unchecked
+                        if item.checkState(column) == Qt.Checked
+                        else Qt.Checked
+                    )
 
-            item.setCheckState(column, state_to_be_set)
+                item.setCheckState(column, state_to_be_set)
+        elif column == 6:
+            for idx, item in enumerate(
+                iter_tree_widget(self.image_list_tree_widget.invisibleRootItem())
+            ):
+                if idx == 0:
+                    continue
+                item.setText(6, self.image_list_tree_widget.selectedItems()[0].text(6))
 
     @Slot(QTreeWidgetItem, int)
-    def onDoubleClick(self, item, column):
+    def onItemDoubleClick(self, item, column):
         item.setFlags(item.flags() | Qt.ItemIsEditable)
         if column == 6:
             self.image_list_tree_widget.editItem(item, column)

--- a/aydin/gui/tabs/qt/images.py
+++ b/aydin/gui/tabs/qt/images.py
@@ -39,7 +39,7 @@ class ImagesTab(QWidget):
 
         self.image_list_tree_widget = QTreeWidget()
         self.image_list_tree_widget.setHeaderLabels(
-            ['file name', 'denoise', 'axes', 'shape', 'dtype', 'size', 'output path']
+            ['file name', 'denoise', 'axes', 'shape', 'dtype', 'size', 'output folder']
         )
 
         self.image_list_tree_widget.setEditTriggers(QAbstractItemView.NoEditTriggers)

--- a/aydin/gui/tabs/qt/images.py
+++ b/aydin/gui/tabs/qt/images.py
@@ -130,7 +130,7 @@ class ImagesTab(QWidget):
                     human_readable_byte_size(
                         metadata.dtype.itemsize * numpy.prod(metadata.shape)
                     ),
-                    str(pathlib.Path(get_output_image_path(path)[0]).resolve().parent),
+                    str(pathlib.Path(path).resolve().parent),
                 ],
             )
 

--- a/aydin/gui/tabs/qt/images.py
+++ b/aydin/gui/tabs/qt/images.py
@@ -6,6 +6,7 @@ from aydin.gui._qt.custom_widgets.horizontal_line_break_widget import (
     QHorizontalLineBreakWidget,
 )
 from aydin.gui._qt.qtreewidget_utils import iter_tree_widget
+from aydin.io.utils import get_output_image_path
 from aydin.util.misc.units import human_readable_byte_size
 
 
@@ -37,7 +38,7 @@ class ImagesTab(QWidget):
 
         self.image_list_tree_widget = QTreeWidget()
         self.image_list_tree_widget.setHeaderLabels(
-            ['file name', 'denoise', 'axes', 'shape', 'dtype', 'size']
+            ['file name', 'denoise', 'axes', 'shape', 'dtype', 'size', 'output_path']
         )
 
         self.image_list_tree_widget.header().sectionClicked.connect(
@@ -115,6 +116,7 @@ class ImagesTab(QWidget):
                     human_readable_byte_size(
                         metadata.dtype.itemsize * numpy.prod(metadata.shape)
                     ),
+                    get_output_image_path(path)[0],
                 ],
             )
             qtree_widget_item.setCheckState(1, Qt.Checked if denoise else Qt.Unchecked)

--- a/aydin/gui/tabs/qt/images.py
+++ b/aydin/gui/tabs/qt/images.py
@@ -1,4 +1,5 @@
 import numpy
+from PyQt5.QtWidgets import QAbstractItemView
 from qtpy.QtCore import Qt, Slot
 from qtpy.QtWidgets import QWidget, QVBoxLayout, QLabel, QTreeWidgetItem, QTreeWidget
 
@@ -38,13 +39,18 @@ class ImagesTab(QWidget):
 
         self.image_list_tree_widget = QTreeWidget()
         self.image_list_tree_widget.setHeaderLabels(
-            ['file name', 'denoise', 'axes', 'shape', 'dtype', 'size', 'output_path']
+            ['file name', 'denoise', 'axes', 'shape', 'dtype', 'size', 'output path']
         )
+
+        self.image_list_tree_widget.setEditTriggers(QAbstractItemView.NoEditTriggers)
+
+        self.image_list_tree_widget.itemDoubleClicked.connect(self.onDoubleClick)
 
         self.image_list_tree_widget.header().sectionClicked.connect(
             self.onSectionClicked
         )
         self.image_list_tree_widget.header().setSectionsClickable(True)
+
         self.image_list_tree_widget.setColumnWidth(0, 400)
         self.image_list_tree_widget.setColumnWidth(3, 300)
         self.image_list_tree_widget.setColumnWidth(5, 200)
@@ -83,6 +89,12 @@ class ImagesTab(QWidget):
 
             item.setCheckState(column, state_to_be_set)
 
+    @Slot(QTreeWidgetItem, int)
+    def onDoubleClick(self, item, column):
+        item.setFlags(item.flags() | Qt.ItemIsEditable)
+        if column == 6:
+            self.image_list_tree_widget.editItem(item, column)
+
     def onTreeItemChanged(self, item, column):
         if column == 1:
             self.parent.data_model.set_image_to_denoise(
@@ -119,5 +131,6 @@ class ImagesTab(QWidget):
                     get_output_image_path(path)[0],
                 ],
             )
+
             qtree_widget_item.setCheckState(1, Qt.Checked if denoise else Qt.Unchecked)
             qtree_widget_item.setToolTip(0, path)

--- a/aydin/gui/tabs/qt/images.py
+++ b/aydin/gui/tabs/qt/images.py
@@ -1,3 +1,5 @@
+import pathlib
+
 import numpy
 from PyQt5.QtWidgets import QAbstractItemView
 from qtpy.QtCore import Qt, Slot
@@ -128,7 +130,7 @@ class ImagesTab(QWidget):
                     human_readable_byte_size(
                         metadata.dtype.itemsize * numpy.prod(metadata.shape)
                     ),
-                    get_output_image_path(path)[0],
+                    str(pathlib.Path(get_output_image_path(path)[0]).resolve().parent),
                 ],
             )
 

--- a/aydin/gui/tabs/qt/images.py
+++ b/aydin/gui/tabs/qt/images.py
@@ -1,15 +1,19 @@
 import pathlib
-
 import numpy
-from PyQt5.QtWidgets import QAbstractItemView
 from qtpy.QtCore import Qt, Slot
-from qtpy.QtWidgets import QWidget, QVBoxLayout, QLabel, QTreeWidgetItem, QTreeWidget
+from qtpy.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QLabel,
+    QTreeWidgetItem,
+    QTreeWidget,
+    QAbstractItemView,
+)
 
 from aydin.gui._qt.custom_widgets.horizontal_line_break_widget import (
     QHorizontalLineBreakWidget,
 )
 from aydin.gui._qt.qtreewidget_utils import iter_tree_widget
-from aydin.io.utils import get_output_image_path
 from aydin.util.misc.units import human_readable_byte_size
 
 

--- a/aydin/gui/tabs/qt/images.py
+++ b/aydin/gui/tabs/qt/images.py
@@ -106,6 +106,10 @@ class ImagesTab(QWidget):
             self.parent.data_model.set_image_to_denoise(
                 item.text(0), item.checkState(1)
             )
+        elif column == 6:
+            self.parent.data_model.update_image_output_folder(
+                item.text(0), item.text(6)
+            )
 
     def remove_items_from_tree(self):
         self.image_list_tree_widget.clear()
@@ -122,7 +126,15 @@ class ImagesTab(QWidget):
 
         self.image_list_tree_widget.clear()
 
-        for filename, array, metadata, train_on, denoise, path in imagelist:
+        for (
+            filename,
+            array,
+            metadata,
+            train_on,
+            denoise,
+            path,
+            output_folder,
+        ) in imagelist:
             qtree_widget_item = QTreeWidgetItem(
                 self.image_list_tree_widget,
                 [
@@ -134,7 +146,7 @@ class ImagesTab(QWidget):
                     human_readable_byte_size(
                         metadata.dtype.itemsize * numpy.prod(metadata.shape)
                     ),
-                    str(pathlib.Path(path).resolve().parent),
+                    output_folder,
                 ],
             )
 


### PR DESCRIPTION
This PR is adding a column on the images tab to expose the output path that will be used to write the resulting denoised image. This feature is requested by @li-li-github first but I think will be helpful to many. Initial design of the idea can be seen in the screenshot here:

![image](https://user-images.githubusercontent.com/15677695/150575648-ba213568-ca16-4e35-9706-59102c6fc02f.png)
 

One thing worth to mention, it is common to have users want to output everything into one specific folder location. We should try to enable an easy way to just set one output folder as well.