### PR TITLE
pyinstaller version upgraded

### DIFF
--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -3,4 +3,4 @@ flake8==4.0.1
 mock==4.0.3
 pre-commit>=1.16.1
 pytest==6.2.5
-pyinstaller==4.4
+pyinstaller==4.8


### PR DESCRIPTION
This PR upgrades pyinstaller dependency to 4.8. Version 4.4 was causing import error related to `pkgutil` hook.