### PR TITLE
GUI: Removing train_on field from data model

### DIFF
--- a/aydin/gui/_qt/job_runners/denoise_job_runner.py
+++ b/aydin/gui/_qt/job_runners/denoise_job_runner.py
@@ -109,8 +109,8 @@ class DenoiseJobRunner(QWidget):
 
     def prep_and_run(self):
         # Get images and their related data
-        self.image_paths = [i[5] for i in self.parent.data_model.images_to_denoise]
-        self.output_folders = [i[6] for i in self.parent.data_model.images_to_denoise]
+        self.image_paths = [i[4] for i in self.parent.data_model.images_to_denoise]
+        self.output_folders = [i[5] for i in self.parent.data_model.images_to_denoise]
         if len(self.image_paths) == 0:
             lprint("Aydin cannot be started with no image")
             return

--- a/aydin/gui/main_page.py
+++ b/aydin/gui/main_page.py
@@ -309,7 +309,7 @@ class MainPage(QWidget):
 
         if path is None:
             image_paths = [
-                get_options_json_path(i[5]) for i in self.data_model.images_to_denoise
+                get_options_json_path(i[4]) for i in self.data_model.images_to_denoise
             ]
         else:
             image_paths = [path]

--- a/aydin/gui/tabs/data_model.py
+++ b/aydin/gui/tabs/data_model.py
@@ -112,7 +112,7 @@ class DataModel:
         self._images.clear()
         self.update_images_tabview()
 
-    def add_images(self, new_images, train_on=True, denoise=True):
+    def add_images(self, new_images, denoise=True):
         """Adds images to the model. Method also triggers
         needed updates on images view.
 
@@ -122,7 +122,6 @@ class DataModel:
             Expects a particular dict format where key is
             the filepath and value is tuple of corresponding
             array and metadata.
-        train_on : bool, optional
         denoise : bool, optional
 
         """
@@ -132,7 +131,6 @@ class DataModel:
                     Path(path).name,
                     array,
                     metadata,
-                    train_on,
                     denoise,
                     path,
                     str(pathlib.Path(path).resolve().parent),

--- a/aydin/gui/tabs/data_model.py
+++ b/aydin/gui/tabs/data_model.py
@@ -151,7 +151,7 @@ class DataModel:
         indices2remove = []
         for idx, imagelist_item in enumerate(self._images):
             if (
-                Path(image_filepath).parents[0] == Path(imagelist_item[5]).parents[0]
+                Path(image_filepath).parents[0] == Path(imagelist_item[4]).parents[0]
                 and Path(image_filepath).name in imagelist_item[0]
             ):
                 indices2remove.append(idx)
@@ -171,7 +171,7 @@ class DataModel:
         List[List[str, numpy.typing.ArrayLike, FileMetadata, bool, bool, str]]
 
         """
-        return list(filter(lambda image: image[4], self.images))
+        return list(filter(lambda image: image[3], self.images))
 
     def set_image_to_denoise(self, filename, new_value):
         """Method to mark/unmark to denoise an image the with
@@ -185,7 +185,7 @@ class DataModel:
         """
         for imagelist_item in self._images:
             if imagelist_item[0] == filename:
-                imagelist_item[4] = new_value
+                imagelist_item[3] = new_value
                 self.update_dimensions_tabview()
                 self.update_cropping_tabview()
 
@@ -193,7 +193,7 @@ class DataModel:
         #  TODO: write proper docstrings here
         for imagelist_item in self._images:
             if imagelist_item[0] == filename:
-                imagelist_item[6] = new_value
+                imagelist_item[5] = new_value
 
     def set_split_channels(self, filename, filepath, new_value: bool):
         """Method to split/de-split channels of an image with
@@ -288,7 +288,7 @@ class DataModel:
 
                 # Prepare file name and path for the hyperstacked image
                 hyperstacked_filename = f"hyperstack_{self.images[0][0]}"
-                filepath = self.images[0][5]
+                filepath = self.images[0][4]
                 hyperstacked_filepath = filepath.replace(
                     Path(filepath).name, hyperstacked_filename
                 )

--- a/aydin/gui/tabs/qt/images.py
+++ b/aydin/gui/tabs/qt/images.py
@@ -138,7 +138,6 @@ class ImagesTab(QWidget):
             filename,
             array,
             metadata,
-            train_on,
             denoise,
             path,
             output_folder,


### PR DESCRIPTION
This PR is an attempt to clean the data model from `train_on` field and its related pieces. We do not have `train_on` field on the Aydin Studio for quite some time and this field in the model became redundant.