### PR TITLE
GUI: Load pretrained models

### DIFF
--- a/aydin/gui/_qt/custom_widgets/denoise_tab_pretrained_method.py
+++ b/aydin/gui/_qt/custom_widgets/denoise_tab_pretrained_method.py
@@ -1,11 +1,5 @@
 from qtpy.QtCore import Qt
-from qtpy.QtWidgets import (
-    QWidget,
-    QHBoxLayout,
-    QVBoxLayout,
-    QLabel,
-    QScrollArea,
-)
+from qtpy.QtWidgets import QWidget, QHBoxLayout, QVBoxLayout, QLabel, QScrollArea
 
 from aydin.gui._qt.custom_widgets.vertical_line_break_widget import (
     QVerticalLineBreakWidget,

--- a/aydin/gui/_qt/custom_widgets/denoise_tab_pretrained_method.py
+++ b/aydin/gui/_qt/custom_widgets/denoise_tab_pretrained_method.py
@@ -1,0 +1,53 @@
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import (
+    QWidget,
+    QHBoxLayout,
+    QVBoxLayout,
+    QLabel,
+    QScrollArea,
+)
+
+from aydin.gui._qt.custom_widgets.vertical_line_break_widget import (
+    QVerticalLineBreakWidget,
+)
+
+
+class DenoiseTabPretrainedMethodWidget(QWidget):
+    def __init__(self, parent, loaded_it):
+        super(QWidget, self).__init__(parent)
+
+        self.parent = parent
+        self.loaded_it = loaded_it
+        self.description = f"This is a pretrained model, namely uses the image translator: {loaded_it.__class__.__name__}, will not train anything new but will quickly infer on the images of your choice."
+
+        # Widget layout
+        self.layout = QHBoxLayout()
+        self.tab_method_layout = QVBoxLayout()
+        self.tab_method_layout.setAlignment(Qt.AlignTop)
+
+        # Description Label
+        self.description_scroll = QScrollArea()
+        self.description_scroll.setStyleSheet("QScrollArea {border: none;}")
+        self.description_scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        self.description_scroll.setAlignment(Qt.AlignTop)
+        self.description_label = QLabel(self.description)
+        self.description_label.setWordWrap(True)
+
+        self.description_label.setTextFormat(Qt.RichText)
+        self.description_label.setOpenExternalLinks(True)
+
+        self.description_label.setAlignment(Qt.AlignTop)
+        self.description_scroll.setWidget(self.description_label)
+        self.description_scroll.setWidgetResizable(True)
+        self.description_scroll.setMinimumHeight(300)
+
+        self.tab_method_layout.addWidget(self.description_scroll)
+
+        self.right_side_vlayout = QVBoxLayout()
+        self.right_side_vlayout.setAlignment(Qt.AlignTop)
+
+        self.layout.addLayout(self.tab_method_layout, 35)
+        self.layout.addWidget(QVerticalLineBreakWidget(self))
+        self.layout.addLayout(self.right_side_vlayout, 50)
+
+        self.setLayout(self.layout)

--- a/aydin/gui/gui.py
+++ b/aydin/gui/gui.py
@@ -90,6 +90,13 @@ class App(QMainWindow):
         )
         runMenu.addAction(saveOptionsJSONButton)
 
+        loadPretrainedModelButton = QAction('Load Pretrained Model', self)
+        loadPretrainedModelButton.setStatusTip('Load Pretrained Model')
+        loadPretrainedModelButton.triggered.connect(
+            lambda: self.main_widget.load_pretrained_model()
+        )
+        runMenu.addAction(loadPretrainedModelButton)
+
         # Preferences Menu
         self.basicModeButton = QAction('Basic mode', self)
         self.basicModeButton.setEnabled(False)

--- a/aydin/gui/main_page.py
+++ b/aydin/gui/main_page.py
@@ -5,6 +5,7 @@ from qtpy.QtWidgets import (
     QVBoxLayout,
     QHBoxLayout,
     QPushButton,
+    QFileDialog,
     QTabWidget,
     QApplication,
     QStyle,
@@ -318,7 +319,14 @@ class MainPage(QWidget):
             save_any_json(args_dict, path)
 
     def load_pretrained_model(self):
-        raise NotImplementedError
+        options = QFileDialog.Options()
+        options |= QFileDialog.DontUseNativeDialog
+        files, _ = QFileDialog.getOpenFileNames(
+            self, "Open File(s)", "", "All Files (*)", options=options
+        )
+
+        if files:
+            self.tabs["Denoise"].load_pretrained_model(pretrained_model_files=files)
 
     def filestab_changed(self):
         self.tabs["File(s)"].on_data_model_update()

--- a/aydin/gui/main_page.py
+++ b/aydin/gui/main_page.py
@@ -317,6 +317,9 @@ class MainPage(QWidget):
         for path in image_paths:
             save_any_json(args_dict, path)
 
+    def load_pretrained_model(self):
+        raise NotImplementedError
+
     def filestab_changed(self):
         self.tabs["File(s)"].on_data_model_update()
 

--- a/aydin/gui/tabs/qt/denoise.py
+++ b/aydin/gui/tabs/qt/denoise.py
@@ -57,6 +57,9 @@ class DenoiseTab(QWidget):
 
         self.leftlist = QListWidget()
 
+        self.loaded_backend_options = []
+        self.loaded_backend_options_descriptions = []
+
         (
             backend_options,
             backend_options_descriptions,

--- a/aydin/gui/tabs/qt/denoise.py
+++ b/aydin/gui/tabs/qt/denoise.py
@@ -174,5 +174,7 @@ class DenoiseTab(QWidget):
 
         """
         for file in pretrained_model_files:
+            print(file)
             shutil.unpack_archive(file, os.path.dirname(file), "zip")
             self.loaded_backends.append(ImageTranslatorBase.load(file[:-4]))
+            shutil.rmtree(file[:-4])

--- a/aydin/gui/tabs/qt/denoise.py
+++ b/aydin/gui/tabs/qt/denoise.py
@@ -185,6 +185,12 @@ class DenoiseTab(QWidget):
 
     def refresh_pretrained_backends(self):
 
+        for index in range(self.leftlist.count() - 1, -1, -1):
+            if "pretrained" in self.leftlist.item(index).text():
+                print(index)
+                self.leftlist.takeItem(index)
+                self.stacked_widget.removeWidget(self.stacked_widget.widget(index))
+
         for index, option in enumerate(self.loaded_backends):
             self.leftlist.insertItem(
                 self.leftlist.count() + index, f"pretrained-{index}"

--- a/aydin/gui/tabs/qt/denoise.py
+++ b/aydin/gui/tabs/qt/denoise.py
@@ -157,3 +157,14 @@ class DenoiseTab(QWidget):
                 widget_index
             ).constructor_arguments_widget_dict.items():
                 constructor_arguments_widget.set_advanced_enabled(enable=enable)
+
+    def load_pretrained_model(self, pretrained_model_files):
+        """
+
+        Parameters
+        ----------
+        pretrained_model_files : list
+            list of paths to the loaded pretrained model files
+
+        """
+        raise NotImplementedError

--- a/aydin/gui/tabs/qt/denoise.py
+++ b/aydin/gui/tabs/qt/denoise.py
@@ -1,3 +1,6 @@
+import os
+import shutil
+
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import (
     QWidget,
@@ -12,6 +15,7 @@ from aydin.gui._qt.custom_widgets.horizontal_line_break_widget import (
     QHorizontalLineBreakWidget,
 )
 from aydin.gui._qt.custom_widgets.readmoreless_label import QReadMoreLessLabel
+from aydin.it.base import ImageTranslatorBase
 from aydin.restoration.denoise.util.denoise_utils import (
     get_list_of_denoiser_implementations,
 )
@@ -57,8 +61,7 @@ class DenoiseTab(QWidget):
 
         self.leftlist = QListWidget()
 
-        self.loaded_backend_options = []
-        self.loaded_backend_options_descriptions = []
+        self.loaded_backends = []
 
         (
             backend_options,
@@ -170,4 +173,6 @@ class DenoiseTab(QWidget):
             list of paths to the loaded pretrained model files
 
         """
-        raise NotImplementedError
+        for file in pretrained_model_files:
+            shutil.unpack_archive(file, os.path.dirname(file), "zip")
+            self.loaded_backends.append(ImageTranslatorBase.load(file[:-4]))

--- a/aydin/gui/tabs/qt/denoise.py
+++ b/aydin/gui/tabs/qt/denoise.py
@@ -167,6 +167,8 @@ class DenoiseTab(QWidget):
             ).constructor_arguments_widget_dict.items():
                 constructor_arguments_widget.set_advanced_enabled(enable=enable)
 
+        self.refresh_pretrained_backends()
+
     def load_pretrained_model(self, pretrained_model_files):
         """
 
@@ -187,7 +189,6 @@ class DenoiseTab(QWidget):
 
         for index in range(self.leftlist.count() - 1, -1, -1):
             if "pretrained" in self.leftlist.item(index).text():
-                print(index)
                 self.leftlist.takeItem(index)
                 self.stacked_widget.removeWidget(self.stacked_widget.widget(index))
 

--- a/aydin/gui/tabs/qt/denoise.py
+++ b/aydin/gui/tabs/qt/denoise.py
@@ -11,6 +11,9 @@ from qtpy.QtWidgets import (
 )
 
 from aydin.gui._qt.custom_widgets.denoise_tab_method import DenoiseTabMethodWidget
+from aydin.gui._qt.custom_widgets.denoise_tab_pretrained_method import (
+    DenoiseTabPretrainedMethodWidget,
+)
 from aydin.gui._qt.custom_widgets.horizontal_line_break_widget import (
     QHorizontalLineBreakWidget,
 )
@@ -174,7 +177,19 @@ class DenoiseTab(QWidget):
 
         """
         for file in pretrained_model_files:
-            print(file)
             shutil.unpack_archive(file, os.path.dirname(file), "zip")
             self.loaded_backends.append(ImageTranslatorBase.load(file[:-4]))
             shutil.rmtree(file[:-4])
+
+        self.refresh_pretrained_backends()
+
+    def refresh_pretrained_backends(self):
+
+        for index, option in enumerate(self.loaded_backends):
+            self.leftlist.insertItem(
+                self.leftlist.count() + index, f"pretrained-{index}"
+            )
+
+            self.stacked_widget.addWidget(
+                DenoiseTabPretrainedMethodWidget(self, option)
+            )

--- a/aydin/gui/tabs/qt/images.py
+++ b/aydin/gui/tabs/qt/images.py
@@ -134,14 +134,7 @@ class ImagesTab(QWidget):
 
         self.image_list_tree_widget.clear()
 
-        for (
-            filename,
-            array,
-            metadata,
-            denoise,
-            path,
-            output_folder,
-        ) in imagelist:
+        for (filename, array, metadata, denoise, path, output_folder) in imagelist:
             qtree_widget_item = QTreeWidgetItem(
                 self.image_list_tree_widget,
                 [

--- a/aydin/gui/tabs/qt/images.py
+++ b/aydin/gui/tabs/qt/images.py
@@ -1,4 +1,3 @@
-import pathlib
 import numpy
 from qtpy.QtCore import Qt, Slot
 from qtpy.QtWidgets import (

--- a/aydin/nn/models/torch/test/test_torch_models.py
+++ b/aydin/nn/models/torch/test/test_torch_models.py
@@ -50,26 +50,14 @@ def test_supervised_2D_n2t():
     reload_best_model_period = 1024
     best_val_loss_value = math.inf
 
-    dataset = TorchDataset(
-        input_image,
-        lizard_image,
-        64,
-        self_supervised=False,
-    )
+    dataset = TorchDataset(input_image, lizard_image, 64, self_supervised=False)
 
     data_loader = DataLoader(
-        dataset,
-        batch_size=1,
-        shuffle=True,
-        num_workers=0,
-        pin_memory=True,
+        dataset, batch_size=1, shuffle=True, num_workers=0, pin_memory=True
     )
 
     model = UNetModel(
-        nb_unet_levels=2,
-        supervised=True,
-        spacetime_ndim=2,
-        residual=True,
+        nb_unet_levels=2, supervised=True, spacetime_ndim=2, residual=True
     )
 
     n2t_unet_train_loop(input_image, lizard_image, model, data_loader)

--- a/aydin/nn/models/utils/torch_dataset.py
+++ b/aydin/nn/models/utils/torch_dataset.py
@@ -13,10 +13,7 @@ class TorchDataset(Dataset):
 
         def extract(image):
             return extract_tiles(
-                image,
-                tile_size=tilesize,
-                extraction_step=tilesize,
-                flatten=True,
+                image, tile_size=tilesize, extraction_step=tilesize, flatten=True
             )
 
         bc_flat_input_image = input_image.reshape(-1, *input_image.shape[2:])


### PR DESCRIPTION
This PR implements required changes to enable loading/re-using previously trained Aydin models on Aydin Studio. Currently, it is possible to re-use previously trained models on Aydin CLI and Aydin API. This PR implements basically the same behavior on Aydin Studio. 