### PR TITLE
DOC: sphinx-copybuton

### DIFF
--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -1,3 +1,4 @@
 numpydoc==1.1.0
 sphinx==4.2.0
 sphinx-rtd-theme==1.0.0
+sphinx-copybutton==0.4.0

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -39,6 +39,7 @@ extensions = [
     "sphinx.ext.autosummary",
     "sphinx.ext.extlinks",
     "sphinx.ext.viewcode",
+    "sphinx_copybutton",
     "numpydoc",
     "sphinx_rtd_theme",
     # "sphinx_click.ext",


### PR DESCRIPTION
This PR adds `sphinx-copybutton` as a dependency and enables a copy button next to the code pieces in our docs. Quite neat.