### PR TITLE
Scipy version fix

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -46,6 +46,7 @@ install_requires =
     QDarkStyle==3.0.2
     qtpy==1.11.2
     scikit-image==0.18.3
+    scipy==1.7.3
     tensorflow==2.7.0
     torch==1.10.1
     keras==2.7.0


### PR DESCRIPTION
This PR fixes scipy version to `1.7.3` for now as some of the endpoints not supported anymore in the latest version as expressed in #99 .