### PR TITLE
numpy sqrt refactor

### DIFF
--- a/aydin/it/classic_denoisers/butterworth.py
+++ b/aydin/it/classic_denoisers/butterworth.py
@@ -279,5 +279,5 @@ def _apw(freq_cutoff, max_padding):
 
 
 def _filter(image_f, f, order):
-    image_f *= (1 + numpy.sqrt(f) ** (2 * order)) ** (-0.5)
+    image_f *= 1 / numpy.sqrt(1 + numpy.sqrt(f) ** (2 * order))
     return image_f

--- a/aydin/it/classic_denoisers/spectral.py
+++ b/aydin/it/classic_denoisers/spectral.py
@@ -364,7 +364,7 @@ def _compute_distance_image_for_fft(freq_cutoff, shape, selected_axes):
 
 
 def _filter(image_f, f, order):
-    factor = (1.0 + numpy.sqrt(f) ** (2 * order)) ** (-0.5)
+    factor = 1 / numpy.sqrt(1.0 + numpy.sqrt(f) ** (2 * order))
     factor = factor.astype(numpy.float32)
     n = image_f.shape[0]
     for i in prange(n):


### PR DESCRIPTION
This PR refactors a couple places where we call `** (-0.5)` instead of `1/numpy.sqrt`. For reasoning see this: https://github.com/numpy/numpy/issues/9363