### PR TITLE
FGR blind_spots argumet duplication fix

### DIFF
--- a/aydin/it/fgr.py
+++ b/aydin/it/fgr.py
@@ -29,7 +29,7 @@ class ImageTranslatorFGR(ImageTranslatorBase):
         voxel_keep_ratio: float = 1,
         max_voxels_for_training: Optional[int] = None,
         favour_bright_pixels: float = 0,
-        blind_spots: Optional[Union[str, List[Tuple[int]]]] = None,
+        blind_spots: Optional[Union[str, List[Tuple[int]]]] = 'auto',
         tile_min_margin: int = 8,
         tile_max_margin: Optional[int] = None,
         max_memory_usage_ratio: float = 0.9,

--- a/aydin/restoration/denoise/noise2selffgr.py
+++ b/aydin/restoration/denoise/noise2selffgr.py
@@ -253,7 +253,6 @@ class Noise2SelfFGR(DenoiseRestorationBase):
                 **self.lower_level_args["it"]["kwargs"]
                 if self.lower_level_args is not None
                 else {},
-                blind_spots='auto',  # TODO: ACS: please set this as default upstream
             )
 
         return it


### PR DESCRIPTION
This PR fixes the blind_spots argument duplication bug.

I set the blind spot argument to auto by default on fgr level as we were trying to achieve same before on restoration level and prevented duplicating keyword this way