### PR TITLE
GUI: Text wrapping for parameter names

### DIFF
--- a/aydin/gui/_qt/custom_widgets/constructor_arguments.py
+++ b/aydin/gui/_qt/custom_widgets/constructor_arguments.py
@@ -31,6 +31,7 @@ class ConstructorArgumentsWidget(QWidget):
         for index, (name, default_value) in enumerate(zip(arg_names, arg_defaults)):
             param_name = name.strip().replace('_', ' ')
             param_label = QLabel(f"{param_name}: ")
+            param_label.setWordWrap(True)
             param_label.setToolTip(f"{param_name}")
 
             if default_value is None:


### PR DESCRIPTION
This PR enables line wrapping for parameter names on processing and denoising tabs.