### PR TITLE
BUG: Build scipy missing hooks

### DIFF
--- a/build/linux/hooks/hook-scipy.py
+++ b/build/linux/hooks/hook-scipy.py
@@ -1,0 +1,5 @@
+from PyInstaller.utils.hooks import collect_submodules
+from PyInstaller.utils.hooks import collect_data_files
+hiddenimports = collect_submodules('scipy')
+
+datas = collect_data_files('scipy')

--- a/build/osx/hooks/hook-scipy.py
+++ b/build/osx/hooks/hook-scipy.py
@@ -1,0 +1,5 @@
+from PyInstaller.utils.hooks import collect_submodules
+from PyInstaller.utils.hooks import collect_data_files
+hiddenimports = collect_submodules('scipy')
+
+datas = collect_data_files('scipy')

--- a/build/win/hooks/hook-scipy.py
+++ b/build/win/hooks/hook-scipy.py
@@ -1,0 +1,5 @@
+from PyInstaller.utils.hooks import collect_submodules
+from PyInstaller.utils.hooks import collect_data_files
+hiddenimports = collect_submodules('scipy')
+
+datas = collect_data_files('scipy')


### PR DESCRIPTION
This PR addresses the bug occurred in our build pipelines after adding new `scipy` API calls to our codebase. 