### PR TITLE
GUI: Removing pyqt5 imports

### DIFF
--- a/aydin/gui/_qt/custom_widgets/program_flow_diagram.py
+++ b/aydin/gui/_qt/custom_widgets/program_flow_diagram.py
@@ -1,7 +1,7 @@
-from PyQt5.QtWidgets import QMenu
 from qtpy.QtWidgets import (
     QHBoxLayout,
     QWidget,
+    QMenu,
     QPushButton,
     QToolButton,
     QStyle,


### PR DESCRIPTION
This PR removes the remaining pyqt5 imports that we forgot while switching to qtpy. 