### PR TITLE
GUI: Super class call bug fix

### DIFF
--- a/aydin/gui/_qt/custom_widgets/activity_widget.py
+++ b/aydin/gui/_qt/custom_widgets/activity_widget.py
@@ -26,7 +26,7 @@ class ActivityWidget(QWidget):
     """
 
     def __init__(self, parent):
-        super(QWidget, self).__init__(parent)
+        super(ActivityWidget, self).__init__(parent)
 
         self.parent = parent
 

--- a/aydin/gui/_qt/custom_widgets/constructor_arguments.py
+++ b/aydin/gui/_qt/custom_widgets/constructor_arguments.py
@@ -18,7 +18,7 @@ class ConstructorArgumentsWidget(QWidget):
         reference_class=None,
         disable_spatial_features=False,
     ):
-        super(QWidget, self).__init__(parent)
+        super(ConstructorArgumentsWidget, self).__init__(parent)
         self.parent = parent
 
         self.arg_names = []

--- a/aydin/gui/_qt/custom_widgets/denoise_tab_method.py
+++ b/aydin/gui/_qt/custom_widgets/denoise_tab_method.py
@@ -21,7 +21,7 @@ class DenoiseTabMethodWidget(QWidget):
     def __init__(
         self, parent, name=None, description=None, disable_spatial_features=False
     ):
-        super(QWidget, self).__init__(parent)
+        super(DenoiseTabMethodWidget, self).__init__(parent)
 
         self.parent = parent
         self.name = name

--- a/aydin/gui/_qt/custom_widgets/denoise_tab_pretrained_method.py
+++ b/aydin/gui/_qt/custom_widgets/denoise_tab_pretrained_method.py
@@ -15,7 +15,7 @@ from aydin.gui._qt.custom_widgets.vertical_line_break_widget import (
 
 class DenoiseTabPretrainedMethodWidget(QWidget):
     def __init__(self, parent, loaded_it):
-        super(QWidget, self).__init__(parent)
+        super(DenoiseTabPretrainedMethodWidget, self).__init__(parent)
 
         self.parent = parent
         self.loaded_it = loaded_it

--- a/aydin/gui/_qt/custom_widgets/horizontal_line_break_widget.py
+++ b/aydin/gui/_qt/custom_widgets/horizontal_line_break_widget.py
@@ -4,7 +4,7 @@ from qtpy.QtCore import Qt
 
 class QHorizontalLineBreakWidget(QWidget):
     def __init__(self, parent):
-        super(QWidget, self).__init__(parent)
+        super(QHorizontalLineBreakWidget, self).__init__(parent)
         self.parent = parent
 
         self.layout = QHBoxLayout()

--- a/aydin/gui/_qt/custom_widgets/program_flow_diagram.py
+++ b/aydin/gui/_qt/custom_widgets/program_flow_diagram.py
@@ -15,7 +15,7 @@ from aydin.io.datasets import examples_single
 
 class QProgramFlowDiagramWidget(QWidget):
     def __init__(self, parent):
-        super(QWidget, self).__init__(parent)
+        super(QProgramFlowDiagramWidget, self).__init__(parent)
         self.parent = parent
         self.highlightable_buttons = []
 

--- a/aydin/gui/_qt/custom_widgets/qt_range_slider.py
+++ b/aydin/gui/_qt/custom_widgets/qt_range_slider.py
@@ -43,7 +43,7 @@ class QRangeSlider(QWidget):
         parent : qtpy.QtWidgets.QWidget
             Parent widget.
         """
-        super().__init__(parent)
+        super(QRangeSlider, self).__init__(parent)
         self.handle_radius = 8
         self.slider_width = 6
         self.moving = "none"

--- a/aydin/gui/_qt/custom_widgets/qt_range_slider_with_labels.py
+++ b/aydin/gui/_qt/custom_widgets/qt_range_slider_with_labels.py
@@ -5,7 +5,7 @@ from aydin.gui._qt.custom_widgets.qt_range_slider import QHRangeSlider
 
 class QRangeSliderWithLabels(QWidget):
     def __init__(self, parent, label="N/A", size=100, min_length=32):
-        super(QWidget, self).__init__(parent)
+        super(QRangeSliderWithLabels, self).__init__(parent)
         self.parent = parent
         self.size = size
         self.min_length = min_length

--- a/aydin/gui/_qt/custom_widgets/vertical_line_break_widget.py
+++ b/aydin/gui/_qt/custom_widgets/vertical_line_break_widget.py
@@ -4,7 +4,7 @@ from qtpy.QtCore import Qt
 
 class QVerticalLineBreakWidget(QWidget):
     def __init__(self, parent):
-        super(QWidget, self).__init__(parent)
+        super(QVerticalLineBreakWidget, self).__init__(parent)
         self.parent = parent
 
         self.layout = QHBoxLayout()

--- a/aydin/gui/_qt/job_runners/denoise_job_runner.py
+++ b/aydin/gui/_qt/job_runners/denoise_job_runner.py
@@ -22,7 +22,7 @@ from aydin.util.log.log import Log, lprint
 
 class DenoiseJobRunner(QWidget):
     def __init__(self, parent, threadpool, start_button):
-        super(QWidget, self).__init__(parent)
+        super(DenoiseJobRunner, self).__init__(parent)
         self.parent = parent
         self.threadpool = threadpool
         self.start_button = start_button

--- a/aydin/gui/_qt/job_runners/preview_job_runner.py
+++ b/aydin/gui/_qt/job_runners/preview_job_runner.py
@@ -7,7 +7,7 @@ from aydin.util.log.log import Log, lprint
 
 class PreviewJobRunner(QWidget):
     def __init__(self, parent, threadpool):
-        super(QWidget, self).__init__(parent)
+        super(PreviewJobRunner, self).__init__(parent)
         self.parent = parent
         self.threadpool = threadpool
 

--- a/aydin/gui/_qt/job_runners/previewall_job_runner.py
+++ b/aydin/gui/_qt/job_runners/previewall_job_runner.py
@@ -8,7 +8,7 @@ from aydin.util.log.log import Log, lprint
 
 class PreviewAllJobRunner(QWidget):
     def __init__(self, parent, threadpool):
-        super(QWidget, self).__init__(parent)
+        super(PreviewAllJobRunner, self).__init__(parent)
         self.parent = parent
         self.threadpool = threadpool
 

--- a/aydin/gui/gui.py
+++ b/aydin/gui/gui.py
@@ -13,7 +13,7 @@ class App(QMainWindow):
     """GUI app"""
 
     def __init__(self, ver):
-        super(QMainWindow, self).__init__()
+        super(App, self).__init__()
 
         self.version = ver
 

--- a/aydin/gui/main_page.py
+++ b/aydin/gui/main_page.py
@@ -42,7 +42,7 @@ class MainPage(QWidget):
     """
 
     def __init__(self, parent, threadpool, status_bar):
-        super(QWidget, self).__init__(parent)
+        super(MainPage, self).__init__(parent)
         self.parent = parent
         self.threadpool = threadpool
         self.status_bar = status_bar

--- a/aydin/gui/tabs/qt/base_cropping.py
+++ b/aydin/gui/tabs/qt/base_cropping.py
@@ -19,7 +19,7 @@ class BaseCroppingTab(QWidget):
     """Use the sliders to select a region of the image to crop."""
 
     def __init__(self, parent):
-        super(QWidget, self).__init__(parent)
+        super(BaseCroppingTab, self).__init__(parent)
         self.parent = parent
 
         self._image = None

--- a/aydin/gui/tabs/qt/dimensions.py
+++ b/aydin/gui/tabs/qt/dimensions.py
@@ -39,7 +39,7 @@ class DimensionsTab(QWidget):
     """
 
     def __init__(self, parent):
-        super(QWidget, self).__init__(parent)
+        super(DimensionsTab, self).__init__(parent)
         self.parent = parent
 
         self._axes = None

--- a/aydin/gui/tabs/qt/files.py
+++ b/aydin/gui/tabs/qt/files.py
@@ -30,7 +30,7 @@ class FilesTab(QWidget):
     """
 
     def __init__(self, parent):
-        super(QWidget, self).__init__(parent)
+        super(FilesTab, self).__init__(parent)
         self.parent = parent
 
         self._hyperstack_last_fail_state_metadatas = None

--- a/aydin/gui/tabs/qt/images.py
+++ b/aydin/gui/tabs/qt/images.py
@@ -27,7 +27,7 @@ class ImagesTab(QWidget):
     """
 
     def __init__(self, parent):
-        super(QWidget, self).__init__(parent)
+        super(ImagesTab, self).__init__(parent)
         self.parent = parent
 
         self.tab_layout = QVBoxLayout()

--- a/aydin/gui/tabs/qt/summary.py
+++ b/aydin/gui/tabs/qt/summary.py
@@ -33,7 +33,7 @@ class SummaryTab(QWidget):
     """
 
     def __init__(self, parent):
-        super(QWidget, self).__init__(parent)
+        super(SummaryTab, self).__init__(parent)
         self.parent = parent
 
         self.tab_layout = QVBoxLayout()

--- a/aydin/gui/tabs/qt/training_cropping.py
+++ b/aydin/gui/tabs/qt/training_cropping.py
@@ -31,7 +31,7 @@ class TrainingCroppingTab(BaseCroppingTab):
     """
 
     def __init__(self, parent):
-        super().__init__(parent)
+        super(TrainingCroppingTab, self).__init__(parent)
         self.parent = parent
 
         self.use_same_crop_checkbox = QCheckBox("Use same cropping for denoising")


### PR DESCRIPTION
This PR addresses the all gui related derived class super miscalls. In many occasions we were trying  to get  the super of the extended class instead of the super of the class of interest itself.