### PR TITLE
DEP: numexpr version to 2.8.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ install_requires =
     napari==0.4.12
     nd2reader==3.3.0
     numba==0.54.1
-    numexpr==2.7.3
+    numexpr==2.8.1
     numpy>=1.19.2
     pynndescent==0.5.5
     PyQt5==5.15.6


### PR DESCRIPTION
This PR bumps the numexpr version to 2.8.1