### PR TITLE
DOC: Use case updates

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -54,7 +54,7 @@ Aydin is support only on Python 3.9 currently. You can install Aydin with the fo
 
 Requirements
 ~~~~~~~~~~~~~
-While aydin works even on tiny laptops, it will run faster and better if you have
+While Aydin works even on tiny laptops, it will run faster and better if you have
 a Nvidia graphics card. We also recommend at least 16GB of RAM but more is better
 especially for very large gigabyte-sized images. In the absence of a GPU,
 the more CPU cores the better, obviously. Different algorithms have different performance
@@ -96,8 +96,9 @@ If you find Aydin useful and use it in your work, please kindly consider to cite
 
    Introduction <use_cases/introduction.rst>
    Denoising Basics with Aydin <use_cases/basics.rst>
-   Denoising Spinning-Disk Confocal Microscopy Images with Aydin <use_cases/confocal.rst>
-   Denoising OpenCell Images with Aydin <use_cases/opencell.rst>
+   Aydin Denoising of Spinning-Disk Confocal Images of Zebrafish Embryos from Royer Lab (CZ Biohub, San Francisco) <use_cases/confocal_royer.rst>
+   Aydin Denoising Spinning-Disk Confocal Microscopy Images of Mouse embryos from the Maitre Lab (Curie, Paris) <use_cases/confocal_maitre.rst>
+   Aydin Denoising of OpenCell Images <use_cases/opencell.rst>
 
 .. toctree::
    :maxdepth: 1

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -99,6 +99,8 @@ If you find Aydin useful and use it in your work, please kindly consider to cite
    Aydin Denoising of Spinning-Disk Confocal Images of Zebrafish Embryos from Royer Lab (CZ Biohub, San Francisco) <use_cases/confocal_royer.rst>
    Aydin Denoising Spinning-Disk Confocal Microscopy Images of Mouse embryos from the Maitre Lab (Curie, Paris) <use_cases/confocal_maitre.rst>
    Aydin Denoising of OpenCell Images <use_cases/opencell.rst>
+   Aydin Denoising of the Noisy ‘New York’ Test Image <use_cases/newyork.rst>
+
 
 .. toctree::
    :maxdepth: 1

--- a/docs/source/use_cases/confocal.rst
+++ b/docs/source/use_cases/confocal.rst
@@ -1,7 +1,0 @@
-Denoising Spinning-Disk Confocal Microscopy Images with Aydin
-==============================================================
-
-
-.. raw:: html
-
-   <iframe src="https://docs.google.com/document/d/e/2PACX-1vThcNzLy5_VjaH3wBCmvujtnjPOtjjsrFqWb2AW_hOPrB30WWLp4FdA_NhnWxDJdxpmFKl2_Qtf1mgS/pub?embedded=true" height="7380" width="720"></iframe>

--- a/docs/source/use_cases/confocal_maitre.rst
+++ b/docs/source/use_cases/confocal_maitre.rst
@@ -4,5 +4,5 @@ Aydin Denoising Spinning-Disk Confocal Microscopy Images of Mouse embryos from t
 
 .. raw:: html
 
-   <iframe src="https://docs.google.com/document/d/e/2PACX-1vSGUTI3ug6shZscvM-nO4F4-FxJqDILoX-sqVXY4Be4FeMzDar-jvKuGh-RYgW8f84o4bg9aaRrDyo4/pub?embedded=true" height="7380" width="720"></iframe>
+   <iframe src="https://docs.google.com/document/d/e/2PACX-1vSGUTI3ug6shZscvM-nO4F4-FxJqDILoX-sqVXY4Be4FeMzDar-jvKuGh-RYgW8f84o4bg9aaRrDyo4/pub?embedded=true" height="6180" width="720"></iframe>
 

--- a/docs/source/use_cases/confocal_maitre.rst
+++ b/docs/source/use_cases/confocal_maitre.rst
@@ -1,0 +1,8 @@
+Aydin Denoising Spinning-Disk Confocal Microscopy Images of Mouse embryos from the Maitre Lab (Curie, Paris)
+================================================================================================================
+
+
+.. raw:: html
+
+   <iframe src="https://docs.google.com/document/d/e/2PACX-1vSGUTI3ug6shZscvM-nO4F4-FxJqDILoX-sqVXY4Be4FeMzDar-jvKuGh-RYgW8f84o4bg9aaRrDyo4/pub?embedded=true" height="7380" width="720"></iframe>
+

--- a/docs/source/use_cases/confocal_royer.rst
+++ b/docs/source/use_cases/confocal_royer.rst
@@ -1,0 +1,8 @@
+Aydin Denoising of Spinning-Disk Confocal Images of Zebrafish Embryos from Royer Lab (CZ Biohub, San Francisco)
+================================================================================================================
+
+
+.. raw:: html
+
+   <iframe src="https://docs.google.com/document/d/e/2PACX-1vThcNzLy5_VjaH3wBCmvujtnjPOtjjsrFqWb2AW_hOPrB30WWLp4FdA_NhnWxDJdxpmFKl2_Qtf1mgS/pub?embedded=true" height="7380" width="720"></iframe>
+

--- a/docs/source/use_cases/confocal_royer.rst
+++ b/docs/source/use_cases/confocal_royer.rst
@@ -4,5 +4,5 @@ Aydin Denoising of Spinning-Disk Confocal Images of Zebrafish Embryos from Royer
 
 .. raw:: html
 
-   <iframe src="https://docs.google.com/document/d/e/2PACX-1vThcNzLy5_VjaH3wBCmvujtnjPOtjjsrFqWb2AW_hOPrB30WWLp4FdA_NhnWxDJdxpmFKl2_Qtf1mgS/pub?embedded=true" height="7380" width="720"></iframe>
+   <iframe src="https://docs.google.com/document/d/e/2PACX-1vThcNzLy5_VjaH3wBCmvujtnjPOtjjsrFqWb2AW_hOPrB30WWLp4FdA_NhnWxDJdxpmFKl2_Qtf1mgS/pub?embedded=true" height="2880" width="720"></iframe>
 

--- a/docs/source/use_cases/introduction.rst
+++ b/docs/source/use_cases/introduction.rst
@@ -18,7 +18,7 @@ and further improving this material, please check this page for updates!
 #. `Aydin Denoising of Spinning-Disk Confocal Images of Zebrafish Embryos from Royer Lab (CZ Biohub, San Francisco) <confocal_royer.html>`_
 #. `Aydin Denoising Spinning-Disk Confocal Microscopy Images of Mouse embryos from the Maitre Lab (Curie, Paris) <confocal_maitre.html>`_
 #. `Aydin Denoising of OpenCell Images <opencell.html>`_
-
+#. `Aydin Denoising of the Noisy ‘New York’ Test Image <newyork.html>`_
 
 Note: We are always interested in learning about new challenging images, please contact us by filling an issue
 `here <https://github.com/royerlab/aydin/issues>`_ if you face difficulties or have a dataset that resists our methods.

--- a/docs/source/use_cases/introduction.rst
+++ b/docs/source/use_cases/introduction.rst
@@ -15,8 +15,10 @@ post- processing steps, and how to adjust their parameters. We are actively popu
 and further improving this material, please check this page for updates!
 
 #. `Denoising Basics with Aydin <basics.html>`_
-#. `Denoising Spinning-Disk Confocal Microscopy Images with Aydin <confocal.html>`_
-#. `Denoising OpenCell Images with Aydin <opencell.html>`_
+#. `Aydin Denoising of Spinning-Disk Confocal Images of Zebrafish Embryos from Royer Lab (CZ Biohub, San Francisco) <confocal_royer.html>`_
+#. `Aydin Denoising Spinning-Disk Confocal Microscopy Images of Mouse embryos from the Maitre Lab (Curie, Paris) <confocal_maitre.html>`_
+#. `Aydin Denoising of OpenCell Images <opencell.html>`_
+
 
 Note: We are always interested in learning about new challenging images, please contact us by filling an issue
 `here <https://github.com/royerlab/aydin/issues>`_ if you face difficulties or have a dataset that resists our methods.

--- a/docs/source/use_cases/newyork.rst
+++ b/docs/source/use_cases/newyork.rst
@@ -1,0 +1,7 @@
+Aydin Denoising of the Noisy ‘New York’ Test Image
+==============================================================
+
+
+.. raw:: html
+
+   <iframe src="https://docs.google.com/document/d/e/2PACX-1vTN02pamOpFk5MrVg7lLRxwU_I0jj7IvEjUVYIoGEamnDaOXD4RGoiduN0eLrZLCiiwpYQFNvsCJecO/pub?embedded=true" height="9680" width="720"></iframe>

--- a/docs/source/use_cases/opencell.rst
+++ b/docs/source/use_cases/opencell.rst
@@ -1,7 +1,7 @@
-Denoising OpenCell Images with Aydin
+Aydin Denoising of OpenCell Images
 ==============================================================
 
 
 .. raw:: html
 
-   <iframe src="https://docs.google.com/document/d/e/2PACX-1vTb5DWYJSjzmzRyA9gy0Et80tz5AqhN_FW_P1UDMod2jZLwYtaRU7FKxO-RfPJ2hK7kl-weXBTH7GQR/pub?embedded=true" height="7380" width="720"></iframe>
+   <iframe src="https://docs.google.com/document/d/e/2PACX-1vTb5DWYJSjzmzRyA9gy0Et80tz5AqhN_FW_P1UDMod2jZLwYtaRU7FKxO-RfPJ2hK7kl-weXBTH7GQR/pub?embedded=true" height="9380" width="720"></iframe>


### PR DESCRIPTION
This PR applies some updates to use cases section of our docs. Mainly renaming the titles and splitting the confocal use-case into two and adding new york image use case.