### PR TITLE
BUG: Latest protobuf import error resolution

### DIFF
--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -73,8 +73,6 @@ jobs:
           run: |
             python -m pip install --upgrade pip
             pip install -e .
-            pip uninstall protobuf -y
-            pip install --no-binary protobuf protobuf
             pip install pytest==6.2.5
             pip install mock==4.0.3
         - name: Run the tests

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,7 @@ install_requires =
     numba==0.55.1
     numexpr==2.8.1
     numpy>=1.19.2
+    protobuf==3.20.1
     pynndescent==0.5.5
     PyQt5==5.15.6
     QDarkStyle==3.0.2


### PR DESCRIPTION
We are indirectly depending on `protobuf` and with their latest version we started to observe a couple import issues, resolution for now seems to be fixing the protobuf version to a recent but an earlier version. This PR does this.