### PR TITLE
DOC: Chicken embryo use case

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -100,6 +100,7 @@ If you find Aydin useful and use it in your work, please kindly consider to cite
    Spinning-Disk Confocal Images of Zebrafish Embryos <use_cases/confocal_royer.rst>
    Spinning-Disk Confocal Microscopy Images of Mouse Embryos <use_cases/confocal_maitre.rst>
    OpenCell Images <use_cases/opencell.rst>
+   Chicken Embryos LSM 780 Images <use_cases/pourquie.rst>
 
 
 .. toctree::

--- a/docs/source/use_cases/introduction.rst
+++ b/docs/source/use_cases/introduction.rst
@@ -19,6 +19,7 @@ and further improving this material, please check this page for updates!
 #. `Spinning-Disk Confocal Images of Zebrafish Embryos from Royer Lab (CZ Biohub, San Francisco) <confocal_royer.html>`_
 #. `Spinning-Disk Confocal Microscopy Images of Mouse Embryos from the Maitre Lab (Curie, Paris) <confocal_maitre.html>`_
 #. `OpenCell Images <opencell.html>`_
+#. `Chicken Embryos LSM 780 Images from the Pourquie lab (Harvard, Boston) <pourquie.html>`_
 
 
 Note: We are always interested in learning about new challenging images, please contact us by filling an issue

--- a/docs/source/use_cases/pourquie.rst
+++ b/docs/source/use_cases/pourquie.rst
@@ -1,0 +1,8 @@
+Aydin Denoising of Chicken Embryos LSM 780 Images from the Pourquie lab (Harvard, Boston)
+================================================================================================================
+
+
+.. raw:: html
+
+   <iframe src="https://docs.google.com/document/d/e/2PACX-1vRwKoAMXwjKd3M8UaLxnpKVcfm0UR7qVd_ur88FRaTOaWAw-7_7aAPeglnyH4FkI22nIj_408W-daIQ/pub?embedded=true" height="3180" width="720"></iframe>
+


### PR DESCRIPTION
This PR introduces the `Chicken Embryos LSM 780 Images from the Pourquie lab (Harvard, Boston)` use case to our documentation.