### PR TITLE
CLI: Split channels

### DIFF
--- a/aydin/cli/cli.py
+++ b/aydin/cli/cli.py
@@ -18,7 +18,7 @@ from aydin.io.datasets import normalise
 from aydin.it.base import ImageTranslatorBase
 from aydin.restoration.deconvolve.lr import LucyRichardson
 from aydin.io.io import imwrite, imread
-from aydin.io.utils import get_output_image_path, get_save_model_path
+from aydin.io.utils import get_output_image_path, get_save_model_path, split_image_channels
 from aydin.restoration.denoise.util.denoise_utils import get_denoiser_class_instance
 from aydin.util.misc.json import load_any_json
 from aydin.util.log.log import lprint, Log
@@ -257,6 +257,18 @@ def view(files, **kwargs):
 
         for idx, image in enumerate(image_arrays):
             viewer.add_image(image, name=filenames[idx])
+
+
+@cli.command()
+@click.argument('files', nargs=-1)
+@click.option('-s', '--slicing', default='', type=str)
+def split_channels(files, **kwargs):
+    filenames, image_arrays, metadatas = handle_files(files, kwargs['slicing'])
+
+    for filename,  image_array,  metadata in zip(filenames, image_arrays, metadatas):
+        splitted_arrays, splitted_metadatas = split_image_channels(image_array, metadata)
+
+        imwrite()
 
 
 @cli.command()

--- a/aydin/cli/cli.py
+++ b/aydin/cli/cli.py
@@ -18,7 +18,11 @@ from aydin.io.datasets import normalise
 from aydin.it.base import ImageTranslatorBase
 from aydin.restoration.deconvolve.lr import LucyRichardson
 from aydin.io.io import imwrite, imread
-from aydin.io.utils import get_output_image_path, get_save_model_path, split_image_channels
+from aydin.io.utils import (
+    get_output_image_path,
+    get_save_model_path,
+    split_image_channels,
+)
 from aydin.restoration.denoise.util.denoise_utils import get_denoiser_class_instance
 from aydin.util.misc.json import load_any_json
 from aydin.util.log.log import lprint, Log
@@ -265,8 +269,10 @@ def view(files, **kwargs):
 def split_channels(files, **kwargs):
     filenames, image_arrays, metadatas = handle_files(files, kwargs['slicing'])
 
-    for filename,  image_array,  metadata in zip(filenames, image_arrays, metadatas):
-        splitted_arrays, splitted_metadatas = split_image_channels(image_array, metadata)
+    for filename, image_array, metadata in zip(filenames, image_arrays, metadatas):
+        splitted_arrays, splitted_metadatas = split_image_channels(
+            image_array, metadata
+        )
 
         imwrite()
 

--- a/aydin/cli/cli.py
+++ b/aydin/cli/cli.py
@@ -274,8 +274,10 @@ def split_channels(files, **kwargs):
             image_array, metadata
         )
 
-        for splitted_array, splitted_metadata in zip(splitted_arrays, splitted_metadatas):
-            imwrite(splitted_array, filename, metadata, overwrite=False)
+        splitted_filenames = [f"channel_{_}_{filename}" for _ in range(len(splitted_arrays))]
+
+        for splitted_filename, splitted_array, splitted_metadata in zip(splitted_filenames, splitted_arrays, splitted_metadatas):
+            imwrite(splitted_array, splitted_filename, splitted_metadata, overwrite=False)
 
 
 @cli.command()

--- a/aydin/cli/cli.py
+++ b/aydin/cli/cli.py
@@ -267,6 +267,16 @@ def view(files, **kwargs):
 @click.argument('files', nargs=-1)
 @click.option('-s', '--slicing', default='', type=str)
 def split_channels(files, **kwargs):
+    """aydin split-channels command. Takes multi-channel images as
+    input, splits its channels into separate images and writes them
+    back.
+
+    Parameters
+    ----------
+    files
+    kwargs
+
+    """
     filenames, image_arrays, metadatas = handle_files(files, kwargs['slicing'])
 
     for filename, image_array, metadata in zip(filenames, image_arrays, metadatas):

--- a/aydin/cli/cli.py
+++ b/aydin/cli/cli.py
@@ -278,6 +278,7 @@ def split_channels(files, **kwargs):
 
         for splitted_filename, splitted_array, splitted_metadata in zip(splitted_filenames, splitted_arrays, splitted_metadatas):
             imwrite(splitted_array, splitted_filename, splitted_metadata, overwrite=False)
+            lprint(f"writing {splitted_filename} is done.")
 
 
 @cli.command()

--- a/aydin/cli/cli.py
+++ b/aydin/cli/cli.py
@@ -274,10 +274,16 @@ def split_channels(files, **kwargs):
             image_array, metadata
         )
 
-        splitted_filenames = [f"channel_{_}_{filename}" for _ in range(len(splitted_arrays))]
+        splitted_filenames = [
+            f"channel_{_}_{filename}" for _ in range(len(splitted_arrays))
+        ]
 
-        for splitted_filename, splitted_array, splitted_metadata in zip(splitted_filenames, splitted_arrays, splitted_metadatas):
-            imwrite(splitted_array, splitted_filename, splitted_metadata, overwrite=False)
+        for splitted_filename, splitted_array, splitted_metadata in zip(
+            splitted_filenames, splitted_arrays, splitted_metadatas
+        ):
+            imwrite(
+                splitted_array, splitted_filename, splitted_metadata, overwrite=False
+            )
             lprint(f"writing {splitted_filename} is done.")
 
 

--- a/aydin/cli/cli.py
+++ b/aydin/cli/cli.py
@@ -274,7 +274,8 @@ def split_channels(files, **kwargs):
             image_array, metadata
         )
 
-        imwrite()
+        for splitted_array, splitted_metadata in zip(splitted_arrays, splitted_metadatas):
+            imwrite(splitted_array, filename, metadata, overwrite=False)
 
 
 @cli.command()


### PR DESCRIPTION
This PR adds the  cli command `split_channels` which comes handy when processing multichannel images sometimes.