### PR TITLE
Making dependency pinnings bundle only

### DIFF
--- a/aydin/cli/test/test_cli.py
+++ b/aydin/cli/test/test_cli.py
@@ -13,7 +13,7 @@ def test_info():
         print(type(image_path))
 
         runner = CliRunner()
-        result = runner.invoke(cli, ['--debug', 'info', image_path])
+        result = runner.invoke(cli, ['info', image_path, '--slicing', ""])
 
         assert result.exit_code == 0
         assert "Reading" in result.output

--- a/aydin/cli/test/test_cli.py
+++ b/aydin/cli/test/test_cli.py
@@ -9,9 +9,6 @@ def test_info():
     with Log.test_context():
         image_path = examples_single.generic_lizard.get_path()
 
-        print(image_path)
-        print(type(image_path))
-
         runner = CliRunner()
         result = runner.invoke(cli, ['info', image_path, '--slicing', ""])
 

--- a/aydin/cli/test/test_cli.py
+++ b/aydin/cli/test/test_cli.py
@@ -9,8 +9,11 @@ def test_info():
     with Log.test_context():
         image_path = examples_single.generic_lizard.get_path()
 
+        print(image_path)
+        print(type(image_path))
+
         runner = CliRunner()
-        result = runner.invoke(cli, ['info', image_path])
+        result = runner.invoke(cli, ['--debug', 'info', image_path])
 
         assert result.exit_code == 0
         assert "Reading" in result.output

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ install_requires =
     importlib-metadata==4.10.0
     jsonpickle==1.3.0
     lightgbm>=3.3.1
-    napari==0.4.12
+    napari==0.4.15
     nd2reader==3.3.0
     numba==0.55.1
     numexpr==2.8.1
@@ -66,7 +66,7 @@ bundle =
     importlib-metadata==4.10.0
     jsonpickle==1.3.0
     lightgbm==3.3.1
-    napari==0.4.15
+    napari==0.4.12
     nd2reader==3.3.0
     numba==0.55.1
     numexpr==2.8.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,12 +28,12 @@ python_requires = >=3.9
 include_package_data = True
 install_requires =
     catboost>=1.0.5
-    Click==8.0.3
-    czifile==2019.7.2
-    docstring-parser==0.13
+    Click>=8.0.3
+    czifile>=2019.7.2
+    docstring-parser>=0.13
     gdown==4.2.0
     googledrivedownloader==0.4
-    importlib-metadata==4.10.0
+    importlib-metadata>=4.10.0
     jsonpickle==1.3.0
     lightgbm>=3.3.1
     napari==0.4.15
@@ -43,9 +43,9 @@ install_requires =
     numpy>=1.19.2
     protobuf==3.20.1
     pynndescent==0.5.5
-    PyQt5==5.15.6
+    PyQt5>=5.15.6
     QDarkStyle==3.0.2
-    qtpy==1.11.2
+    qtpy>=1.11.2
     scikit-image==0.18.3
     scipy==1.7.3
     tensorflow==2.8.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ install_requires =
     lightgbm>=3.3.1
     napari==0.4.15
     nd2reader==3.3.0
-    numba==0.55.1
+    numba>=0.55.1
     numexpr==2.8.1
     numpy>=1.19.2
     protobuf==3.20.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,36 @@ packages = find:
 python_requires = >=3.9
 include_package_data = True
 install_requires =
+    catboost>=1.0.5
+    Click==8.0.3
+    czifile==2019.7.2
+    docstring-parser==0.13
+    gdown==4.2.0
+    googledrivedownloader==0.4
+    importlib-metadata==4.10.0
+    jsonpickle==1.3.0
+    lightgbm>=3.3.1
+    napari==0.4.12
+    nd2reader==3.3.0
+    numba==0.55.1
+    numexpr==2.8.1
+    numpy>=1.19.2
+    protobuf==3.20.1
+    pynndescent==0.5.5
+    PyQt5==5.15.6
+    QDarkStyle==3.0.2
+    qtpy==1.11.2
+    scikit-image==0.18.3
+    scipy==1.7.3
+    tensorflow==2.8.1
+    torch==1.10.1
+    keras==2.8.0
+    zarr==2.4.0
+    imagecodecs==2022.2.22
+    memoization==0.4.0
+
+[options.extras_require]
+bundle =
     catboost==1.0.5
     Click==8.0.3
     czifile==2019.7.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ python_requires = >=3.9
 include_package_data = True
 install_requires =
     catboost>=1.0.5
-    Click>=8.0.3
+    Click==8.0.3
     czifile>=2019.7.2
     docstring-parser>=0.13
     gdown==4.2.0


### PR DESCRIPTION
To gain more flexibility on extending Aydin in different ways, we need to make the dependency pinnings more relax. Yet we need the strict pinnings for the bundles. This PR refactors the setup.cfg to comfort both needs while moving forward.