### PR TITLE
CLI: slicing option bug is fixed for the test_info

### DIFF
--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -77,5 +77,5 @@ jobs:
             pip install mock==4.0.3
         - name: Run the tests
           run: |
-            python -m pytest . --disable-pytest-warnings --durations=30 --show-capture=stderr
+            python -m pytest aydin/cli/. --disable-pytest-warnings --durations=30
 

--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -77,5 +77,5 @@ jobs:
             pip install mock==4.0.3
         - name: Run the tests
           run: |
-            python -m pytest aydin/cli/. --disable-pytest-warnings --durations=30
+            python -m pytest . --disable-pytest-warnings --durations=30
 

--- a/aydin/cli/test/test_cli.py
+++ b/aydin/cli/test/test_cli.py
@@ -10,7 +10,7 @@ def test_info():
         image_path = examples_single.generic_lizard.get_path()
 
         runner = CliRunner()
-        result = runner.invoke(cli, ['info', image_path])
+        result = runner.invoke(cli, ['info', image_path, '--slicing', ""])
 
         assert result.exit_code == 0
         assert "Reading" in result.output

--- a/aydin/cli/test/test_cli.py
+++ b/aydin/cli/test/test_cli.py
@@ -8,6 +8,7 @@ from aydin.util.log.log import Log
 def test_info():
     with Log.test_context():
         image_path = examples_single.generic_lizard.get_path()
+        print(image_path)
 
         runner = CliRunner()
         result = runner.invoke(cli, ['info', image_path, '--slicing', ""])


### PR DESCRIPTION
This PR fixes the bug of missing option on the test case test_info in `aydin/cli/test/test_cli.py`.