### PR TITLE
napari version bump to 0.4.15

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ install_requires =
     importlib-metadata==4.10.0
     jsonpickle==1.3.0
     lightgbm==3.3.1
-    napari==0.4.12
+    napari==0.4.15
     nd2reader==3.3.0
     numba==0.55.1
     numexpr==2.8.1


### PR DESCRIPTION
This PR changes the napari dependency version to 0.4.15 for better compatibility with existing napari plugins in the ecosystem. 