### PR TITLE
Relaxing pynndescent version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ install_requires =
     numexpr>=2.8.1
     numpy>=1.19.2
     protobuf==3.20.1
-    pynndescent==0.5.5
+    pynndescent>=0.5.5
     PyQt5>=5.15.6
     QDarkStyle==3.0.2
     qtpy>=1.11.2


### PR DESCRIPTION
This PR removes version pinning for `pynndescent` dependency. 