### PR TITLE
GUI: new egg chamber example dataset

### DIFF
--- a/aydin/gui/_qt/custom_widgets/program_flow_diagram.py
+++ b/aydin/gui/_qt/custom_widgets/program_flow_diagram.py
@@ -45,6 +45,7 @@ class QProgramFlowDiagramWidget(QWidget):
             "Blastocyst Fracking (Maitre)": examples_single.maitre_mouse,
             "OpenCell ARHGAP21 (Leonetti)": examples_single.leonetti_arhgap21,
             "OpenCell ANKRD11  (Leonetti)": examples_single.leonetti_ankrd11,
+            "Drosophila Egg Chamber (Machado et al.)": examples_single.machado_drosophile_egg_chamber,
         }
         for item in menu_items.keys():
             action = menu.addAction(item)

--- a/aydin/io/datasets.py
+++ b/aydin/io/datasets.py
@@ -216,6 +216,11 @@ class examples_single(Enum):
         'Royer_confocal_dragonfly_hcr_drerio_30somite_crop.tif',
     )
 
+    machado_drosophile_egg_chamber = (
+        '1msjf1pVAGsy61QMtxvVoxxk5WZCofdN2',
+        'C2-DrosophilaEggChamber-small.tif',
+    )
+
     # 2D+t
     cognet_nanotube1 = (
         '1SmrBheUc6p5qTgtIEzedCwbN87HOW_O_',


### PR DESCRIPTION
This PR introduces the drosophile egg chamber data from LimeSeg Test Datasets(https://zenodo.org/record/1472859) as a new example dataset to Aydin Studio per @royerloic and @haesleinhuepf requested. Also this will enable aydin napari plugin to expose this data as an example data together with the plugin.