### PR TITLE
imagio version fix

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,7 @@ install_requires =
     docstring-parser>=0.13
     gdown>=4.2.0
     importlib-metadata>=4.10.0
+    imageio==2.21.1
     jsonpickle==1.3.0
     lightgbm>=3.3.1
     napari==0.4.15


### PR DESCRIPTION
With the latest version of imageio package we are facing import time errors and for now we can fix our dependency to an earlier release of imageio. 