### PR TITLE
numpy minimum version updated

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ install_requires =
     napari==0.4.15
     nd2reader>=3.3.0
     numba>=0.55.1
-    numpy>=1.19.2
+    numpy>=1.21.2
     protobuf==3.20.1
     pynndescent>=0.5.5
     PyQt5>=5.15.6


### PR DESCRIPTION
Following NEP29, we are increasing the minimum version requirement for numpy dependency.