### PR TITLE
BUG: PSNR function parameter order fix

### DIFF
--- a/aydin/cli/cli.py
+++ b/aydin/cli/cli.py
@@ -315,7 +315,8 @@ def ssim(files, **kwargs):
 @click.argument('files', nargs=2)
 @click.option('-s', '--slicing', default='', type=str)
 def psnr(files, **kwargs):
-    """aydin psnr command
+    """aydin psnr command. First provided image has to be the
+    true image and second one the test image.
 
     Parameters
     ----------

--- a/aydin/cli/test/test_cli.py
+++ b/aydin/cli/test/test_cli.py
@@ -64,11 +64,11 @@ def test_denoise():
 
         # denoised = denoised.clip(0, 1)
         #
-        # psnr_noisy = psnr(noisy, image)
+        # psnr_noisy = psnr(image, noisy)
         # ssim_noisy = ssim(noisy, image)
         # print("noisy", psnr_noisy, ssim_noisy)
         #
-        # psnr_denoised = psnr(denoised, image)
+        # psnr_denoised = psnr(image, denoised)
         # ssim_denoised = ssim(denoised, image)
         # print("denoised", psnr_denoised, ssim_denoised)
         #

--- a/aydin/it/demo/n2s/nn/2D_xybatch.py
+++ b/aydin/it/demo/n2s/nn/2D_xybatch.py
@@ -42,7 +42,7 @@ def demo():
     noisy = numpy.clip(noisy, 0, 1)
     denoised = numpy.clip(denoised, 0, 1)
 
-    print("noisy", psnr(noisy, image), ssim(noisy, image))
+    print("noisy", psnr(image, noisy), ssim(noisy, image))
     print("denoised", psnr(denoised, image), ssim(denoised, image))
     # print("denoised_predict", psnr(denoised_predict, image), ssim(denoised_predict, image))
 

--- a/aydin/it/test/test_classic.py
+++ b/aydin/it/test/test_classic.py
@@ -40,7 +40,7 @@ def do_it_classic(method_name, min_psnr=22, min_ssim=0.75):
     ssim_noisy = ssim(noisy, image)
     print("noisy", psnr_noisy, ssim_noisy)
 
-    psnr_denoised = psnr(image, image)
+    psnr_denoised = psnr(image, denoised)
     ssim_denoised = ssim(denoised, image)
     print("denoised", psnr_denoised, ssim_denoised)
 

--- a/aydin/it/test/test_classic.py
+++ b/aydin/it/test/test_classic.py
@@ -36,11 +36,11 @@ def do_it_classic(method_name, min_psnr=22, min_ssim=0.75):
     noisy = numpy.clip(noisy, 0, 1)
     denoised = numpy.clip(denoised, 0, 1)
 
-    psnr_noisy = psnr(noisy, image)
+    psnr_noisy = psnr(image, noisy)
     ssim_noisy = ssim(noisy, image)
     print("noisy", psnr_noisy, ssim_noisy)
 
-    psnr_denoised = psnr(denoised, image)
+    psnr_denoised = psnr(image, image)
     ssim_denoised = ssim(denoised, image)
     print("denoised", psnr_denoised, ssim_denoised)
 

--- a/aydin/it/test/test_deprecated_cnn.py
+++ b/aydin/it/test/test_deprecated_cnn.py
@@ -70,11 +70,11 @@ def test_it_cnn_shiftconv_light():
     noisy = numpy.clip(noisy.reshape(image.shape), 0, 1)
     denoised = numpy.clip(denoised, 0, 1)
 
-    psnr_noisy = psnr(noisy, image)
+    psnr_noisy = psnr(image, noisy)
     ssim_noisy = ssim(noisy, image)
     print("noisy", psnr_noisy, ssim_noisy)
 
-    psnr_denoised = psnr(denoised, image)
+    psnr_denoised = psnr(image, denoised)
     ssim_denoised = ssim(denoised, image)
     print("denoised", psnr_denoised, ssim_denoised)
 

--- a/aydin/it/test/test_fgr_saveload.py
+++ b/aydin/it/test/test_fgr_saveload.py
@@ -75,18 +75,18 @@ def saveload(generator, regressor, min_psnr=22, min_ssim=0.75):
 
     denoised = denoised.clip(0, 1)
 
-    psnr_noisy = psnr(noisy, image)
+    psnr_noisy = psnr(image, noisy)
     ssim_noisy = ssim(noisy, image)
     print("noisy", psnr_noisy, ssim_noisy)
 
-    psnr_denoised = psnr(denoised, image)
+    psnr_denoised = psnr(image, denoised)
     ssim_denoised = ssim(denoised, image)
     print("denoised", psnr_denoised, ssim_denoised)
 
     assert psnr_denoised > psnr_noisy and ssim_denoised > ssim_noisy
     assert psnr_denoised > psnr_noisy and ssim_denoised > ssim_noisy
 
-    # if the line below fails, then the parameters of the image the lgbm regressohave   been broken.
+    # if the line below fails, then the parameters of the image the lgbm regressor have been broken.
     # do not change the number below, but instead, fix the problem -- most likely a parameter.
 
     assert psnr_denoised > min_psnr and ssim_denoised > min_ssim

--- a/aydin/regression/test/test_regressors.py
+++ b/aydin/regression/test/test_regressors.py
@@ -73,7 +73,7 @@ def with_regressor(data, regressor, min_ssim=0.8):
     denoised = numpy.clip(denoised, 0, 1)
 
     ssim_value = ssim(denoised, image)
-    psnr_value = psnr(denoised, image)
+    psnr_value = psnr(image, denoised)
 
     print("denoised", psnr_value, ssim_value)
 
@@ -95,7 +95,7 @@ def with_regressor(data, regressor, min_ssim=0.8):
     # print(numpy.max(denoised), numpy.max(image))
     denoised = denoised.clip(0, 1)
     ssim_value = ssim(denoised, image)
-    psnr_value = psnr(denoised, image)
+    psnr_value = psnr(image, denoised)
 
     print("denoised", psnr_value, ssim_value)
 

--- a/aydin/restoration/denoise/test/test_saveload.py
+++ b/aydin/restoration/denoise/test/test_saveload.py
@@ -79,12 +79,12 @@ def saveload(denoiser, min_psnr=22, min_ssim=0.75):
 
     denoised = denoised.clip(0, 1)
 
-    psnr_noisy = psnr(noisy, image)
-    ssim_noisy = ssim(noisy, image)
+    psnr_noisy = psnr(image, noisy)
+    ssim_noisy = ssim(image, noisy)
     print("noisy", psnr_noisy, ssim_noisy)
 
-    psnr_denoised = psnr(denoised, image)
-    ssim_denoised = ssim(denoised, image)
+    psnr_denoised = psnr(image, denoised)
+    ssim_denoised = ssim(image, denoised)
     print("denoised", psnr_denoised, ssim_denoised)
 
     # Check if denoised image satisfies some checks


### PR DESCRIPTION
This PR addresses the misusages of `skimage.metrics.peak_signal_noise_ratio` function which requires the true image as the first parameter as shown in docs: https://scikit-image.org/docs/stable/api/skimage.metrics.html#skimage.metrics.peak_signal_noise_ratio.