### PR TITLE
PyQt6

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ install_requires =
     numpy>=1.21.2
     protobuf==3.20.1
     pynndescent>=0.5.5
-    PyQt5>=5.15.6
+    PyQt6>=6.4.0
     QDarkStyle==3.0.2
     qtpy>=1.11.2
     scikit-image==0.18.3


### PR DESCRIPTION
This PR help us drop PyQt5 and adopt PyQt6 as our main gui backend dependency. 